### PR TITLE
pin consul docker to 1.6.1

### DIFF
--- a/instruqt-tracks/consul-basics/config.yml
+++ b/instruqt-tracks/consul-basics/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 containers:
 - name: consul-server-0
-  image: consul
+  image: consul:1.6.1
   ports:
   - 8300
   - 8301
@@ -12,7 +12,7 @@ containers:
     CONSUL_HTTP_ADDR: http://127.0.0.1:8500
   memory: 128
 - name: consul-server-2
-  image: consul
+  image: consul:1.6.1
   ports:
   - 8300
   - 8301
@@ -23,7 +23,7 @@ containers:
     CONSUL_HTTP_ADDR: http://127.0.0.1:8500
   memory: 128
 - name: consul-server-1
-  image: consul
+  image: consul:1.6.1
   ports:
   - 8300
   - 8301
@@ -34,7 +34,7 @@ containers:
     CONSUL_HTTP_ADDR: http://127.0.0.1:8500
   memory: 128
 - name: consul-agent-0
-  image: consul
+  image: consul:1.6.1
   ports:
   - 8300
   - 8301

--- a/instruqt-tracks/consul-basics/track.yml
+++ b/instruqt-tracks/consul-basics/track.yml
@@ -23,8 +23,8 @@ tags:
 - cluster
 owner: hashicorp
 developers:
-- lance@hashicorp.com
-- scarolan@hashicorp.com
+- null
+- null
 private: false
 published: true
 challenges:
@@ -369,4 +369,4 @@ challenges:
     path: /tmp/bootstrap.txt
   difficulty: basic
   timelimit: 600
-checksum: "2071700225202135438"
+checksum: "1745266151377119856"

--- a/instruqt-tracks/service-discovery-with-consul/config.yml
+++ b/instruqt-tracks/service-discovery-with-consul/config.yml
@@ -22,7 +22,7 @@ containers:
     MYSQL_ROOT_PASSWORD: HashiCorp123
     MYSQL_USER: wp-user
 - name: consul-server-0
-  image: consul
+  image: consul:1.6.1
   ports:
   - 8300
   - 8301
@@ -31,7 +31,7 @@ containers:
   - 8600
   memory: 128
 - name: consul-server-1
-  image: consul
+  image: consul:1.6.1
   ports:
   - 8300
   - 8301
@@ -40,7 +40,7 @@ containers:
   - 8600
   memory: 128
 - name: consul-server-2
-  image: consul
+  image: consul:1.6.1
   ports:
   - 8300
   - 8301

--- a/instruqt-tracks/service-discovery-with-consul/track.yml
+++ b/instruqt-tracks/service-discovery-with-consul/track.yml
@@ -17,8 +17,8 @@ tags:
 - consul
 owner: hashicorp
 developers:
-- lance@hashicorp.com
-- scarolan@hashicorp.com
+- null
+- null
 private: false
 published: true
 challenges:
@@ -309,4 +309,4 @@ challenges:
     hostname: app
   difficulty: basic
   timelimit: 900
-checksum: "13185615548126404487"
+checksum: "340507570788199309"

--- a/instruqt-tracks/service-mesh-with-consul/config.yml
+++ b/instruqt-tracks/service-mesh-with-consul/config.yml
@@ -14,7 +14,7 @@ containers:
     WORDPRESS_DB_USER: root
     WORDPRESS_TABLE_PREFIX: wp
 - name: consul-server-0
-  image: consul
+  image: consul:1.6.1
   ports:
   - 8300
   - 8301
@@ -25,7 +25,7 @@ containers:
     CONSUL_HTTP_ADDR: http://127.0.0.1:8500
   memory: 128
 - name: consul-server-1
-  image: consul
+  image: consul:1.6.1
   ports:
   - 8300
   - 8301
@@ -36,7 +36,7 @@ containers:
     CONSUL_HTTP_ADDR: http://127.0.0.1:8500
   memory: 128
 - name: consul-server-2
-  image: consul
+  image: consul:1.6.1
   ports:
   - 8300
   - 8301

--- a/instruqt-tracks/service-mesh-with-consul/track.yml
+++ b/instruqt-tracks/service-mesh-with-consul/track.yml
@@ -12,8 +12,8 @@ icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/c
 tags: []
 owner: hashicorp
 developers:
-- lance@hashicorp.com
-- scarolan@hashicorp.com
+- null
+- null
 private: false
 published: true
 challenges:
@@ -396,4 +396,4 @@ challenges:
     port: 80
   difficulty: basic
   timelimit: 900
-checksum: "15304326842392076046"
+checksum: "525567581682424602"


### PR DESCRIPTION
We need to pin dockerhub consul image since 1.6.2 prevented the Instruqt track Consul Basics from loading due to https://github.com/hashicorp/docker-consul/pull/140/files (according to Instruqt).