### PR TITLE
Automatically update Instruqt CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,8 @@ jobs:
             echo "Running instruqt track test..."
             cd /root/project/instruqt-tracks/consul-basics
             instruqt track test --skip-fail-check
+            echo "Running instruqt track push..."
+            instruqt track push --force
   service-discovery-with-consul:
     docker:
       - image: ubuntu:latest
@@ -82,6 +84,8 @@ jobs:
             cd /root/project/instruqt-tracks/service-discovery-with-consul
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
+            echo "Running instruqt track push..."
+            instruqt track push --force
   service-mesh-with-consul:
     docker:
       - image: ubuntu:latest
@@ -109,6 +113,8 @@ jobs:
             cd /root/project/instruqt-tracks/service-mesh-with-consul
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
+            echo "Running instruqt track push..."
+            instruqt track push --force
   service-mesh-with-consul-k8s:
     docker:
       - image: ubuntu:latest
@@ -136,6 +142,8 @@ jobs:
             cd /root/project/instruqt-tracks/service-mesh-with-consul-k8s
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
+            echo "Running instruqt track push..."
+            instruqt track push --force
   service-mesh-with-consul-hybrid:
     docker:
       - image: ubuntu:latest
@@ -163,6 +171,8 @@ jobs:
             cd /root/project/instruqt-tracks/service-mesh-with-consul-hybrid
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
+            echo "Running instruqt track push..."
+            instruqt track push --force
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,13 @@ jobs:
             unzip instruqt.zip
             cp instruqt /usr/local/bin/instruqt
             chmod +x /usr/local/bin/instruqt
-            instruqt version | grep $VERSION
+            echo "yes" | instruqt version
             RETVAL=$?
             if [[ $RETVAL -ne 0 ]]; then
-              echo "Version $VERSION is not installed correctly."
+              echo "Instruqt is not installed correctly."
               exit 1
             else
-              echo "Instruqt Version $VERSION is installed."
+              echo "Instruqt is installed and updated to most recent version."
             fi
             echo "Running instruqt track validate..."
             for dir in $(ls -d /root/project/instruqt-tracks/*); do
@@ -44,11 +44,17 @@ jobs:
             unzip instruqt.zip
             cp instruqt /usr/local/bin/instruqt
             chmod +x /usr/local/bin/instruqt
-            cd /root/project/instruqt-tracks/consul-basics
+            echo "yes" | instruqt version
+            RETVAL=$?
+            if [[ $RETVAL -ne 0 ]]; then
+              echo "Instruqt is not installed correctly."
+              exit 1
+            else
+              echo "Instruqt is installed and updated to most recent version."
+            fi
             echo "Running instruqt track test..."
+            cd /root/project/instruqt-tracks/consul-basics
             instruqt track test --skip-fail-check
-            echo "Running instruqt track push..."
-            instruqt track push --force
   service-discovery-with-consul:
     docker:
       - image: ubuntu:latest
@@ -65,11 +71,17 @@ jobs:
             unzip instruqt.zip
             cp instruqt /usr/local/bin/instruqt
             chmod +x /usr/local/bin/instruqt
+            echo "yes" | instruqt version
+            RETVAL=$?
+            if [[ $RETVAL -ne 0 ]]; then
+              echo "Instruqt is not installed correctly."
+              exit 1
+            else
+              echo "Instruqt is installed and updated to most recent version."
+            fi
             cd /root/project/instruqt-tracks/service-discovery-with-consul
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
-            echo "Running instruqt track push..."
-            instruqt track push --force
   service-mesh-with-consul:
     docker:
       - image: ubuntu:latest
@@ -86,11 +98,17 @@ jobs:
             unzip instruqt.zip
             cp instruqt /usr/local/bin/instruqt
             chmod +x /usr/local/bin/instruqt
+            echo "yes" | instruqt version
+            RETVAL=$?
+            if [[ $RETVAL -ne 0 ]]; then
+              echo "Instruqt is not installed correctly."
+              exit 1
+            else
+              echo "Instruqt is installed and updated to most recent version."
+            fi
             cd /root/project/instruqt-tracks/service-mesh-with-consul
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
-            echo "Running instruqt track push..."
-            instruqt track push --force
   service-mesh-with-consul-k8s:
     docker:
       - image: ubuntu:latest
@@ -107,11 +125,17 @@ jobs:
             unzip instruqt.zip
             cp instruqt /usr/local/bin/instruqt
             chmod +x /usr/local/bin/instruqt
+            echo "yes" | instruqt version
+            RETVAL=$?
+            if [[ $RETVAL -ne 0 ]]; then
+              echo "Instruqt is not installed correctly."
+              exit 1
+            else
+              echo "Instruqt is installed and updated to most recent version."
+            fi
             cd /root/project/instruqt-tracks/service-mesh-with-consul-k8s
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
-            echo "Running instruqt track push..."
-            instruqt track push --force 
   service-mesh-with-consul-hybrid:
     docker:
       - image: ubuntu:latest
@@ -128,11 +152,17 @@ jobs:
             unzip instruqt.zip
             cp instruqt /usr/local/bin/instruqt
             chmod +x /usr/local/bin/instruqt
+            echo "yes" | instruqt version
+            RETVAL=$?
+            if [[ $RETVAL -ne 0 ]]; then
+              echo "Instruqt is not installed correctly."
+              exit 1
+            else
+              echo "Instruqt is installed and updated to most recent version."
+            fi
             cd /root/project/instruqt-tracks/service-mesh-with-consul-hybrid
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
-            echo "Running instruqt track push..."
-            instruqt track push --force
 workflows:
   version: 2
   build-and-deploy:


### PR DESCRIPTION
Edited .circleci/config.yml to automatically upate Instruqt version to latest version.

Also, I removed `instruqt track push --force` at end.  That is not present for other products and I don't see any reason for it.

Additionally, doing that will cause the checksum in track.yml in Instruqt to change, making it inconsistent with what GitHub has, assuming that people who push tracks run that before doing `git commit` and `git push` so that the checksum is already correct.