### PR TITLE
pinned remark.js to 0.14.0

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/aws/consul-enterprise/index.html
+++ b/docs/slides/aws/consul-enterprise/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/aws/consul-oss/index.html
+++ b/docs/slides/aws/consul-oss/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/aws/index.html
+++ b/docs/slides/aws/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/azure/consul-enterprise/index.html
+++ b/docs/slides/azure/consul-enterprise/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/azure/consul-oss/index.html
+++ b/docs/slides/azure/consul-oss/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/azure/index.html
+++ b/docs/slides/azure/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/gcp/consul-enterprise/index.html
+++ b/docs/slides/gcp/consul-enterprise/index.html
@@ -36,7 +36,7 @@ GC{P}<!DOCTYPE html>
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/gcp/consul-oss/index.html
+++ b/docs/slides/gcp/consul-oss/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/gcp/index.html
+++ b/docs/slides/gcp/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/index.html
+++ b/docs/slides/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/consul-enterprise/index.html
+++ b/docs/slides/multi-cloud/consul-enterprise/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/consul-oss/consul-0.html
+++ b/docs/slides/multi-cloud/consul-oss/consul-0.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/consul-oss/consul-1.html
+++ b/docs/slides/multi-cloud/consul-oss/consul-1.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/consul-oss/consul-2.html
+++ b/docs/slides/multi-cloud/consul-oss/consul-2.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/consul-oss/consul-3.html
+++ b/docs/slides/multi-cloud/consul-oss/consul-3.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/consul-oss/consul-4.html
+++ b/docs/slides/multi-cloud/consul-oss/consul-4.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/consul-oss/consul-5.html
+++ b/docs/slides/multi-cloud/consul-oss/consul-5.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/consul-oss/consul-6.html
+++ b/docs/slides/multi-cloud/consul-oss/consul-6.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/consul-oss/consul-7.html
+++ b/docs/slides/multi-cloud/consul-oss/consul-7.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/consul-oss/consul-99.html
+++ b/docs/slides/multi-cloud/consul-oss/consul-99.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/consul-oss/index.html
+++ b/docs/slides/multi-cloud/consul-oss/index.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/index.html
+++ b/docs/slides/multi-cloud/index.html
@@ -36,7 +36,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;


### PR DESCRIPTION
This locks down remark.js to v0.14.0 since the recent release of 0.15.0 broke all our workshop websites. Previously, we just used https://remarkjs.com/downloads/remark-latest.min.js. Now, I have pinned it to https://remarkjs.com/downloads/remark-0.14.0.min.js until 0.15.x is fixed.