### PR TITLE
misleading statement

### DIFF
--- a/instruqt-tracks/consul-life-of-a-developer/track.yml
+++ b/instruqt-tracks/consul-life-of-a-developer/track.yml
@@ -1064,4 +1064,4 @@ challenges:
     url: https://htmlpreview.github.io/?https://raw.githubusercontent.com/hashicorp/field-workshops-consul/master/instruqt-tracks/consul-life-of-a-developer/assets/diagrams/diagrams.html
   difficulty: basic
   timelimit: 500
-checksum: "7461119048757859475"
+checksum: "3535411516985599699"

--- a/instruqt-tracks/consul-life-of-a-developer/track.yml
+++ b/instruqt-tracks/consul-life-of-a-developer/track.yml
@@ -615,7 +615,7 @@ challenges:
     ```
 
     The dataplane will be updated to reflect this change.
-    The `health_flags` will not be `healthy`. <br>
+    The `health_flags` will be `healthy`. <br>
 
     ```
     kubectl config use-context k8s1


### PR DESCRIPTION
The `health_flags` will be `healthy` as this is after we bring the redis payment service back up (as reflected everywhere including consul ui and dataplane).