### PR TITLE
move consul icon to instruqt-hashicorp project

### DIFF
--- a/instruqt-tracks/consul-basics/track.yml
+++ b/instruqt-tracks/consul-basics/track.yml
@@ -15,7 +15,7 @@ description: |-
   * Add Basic Security with Consul's ACLs
 
   Once you've learned these fundamentals you can proceed to intermediate and advanced topics like Service Discovery and Consul Connect.
-icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/consul.png
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/consul.png
 tags:
 - introduction to consul
 - consul basics

--- a/instruqt-tracks/consul-enterprise-on-aws/track.yml
+++ b/instruqt-tracks/consul-enterprise-on-aws/track.yml
@@ -5,7 +5,7 @@ title: 'DEPRECATED: Consul on AWS'
 teaser: 'See link for new track: https://play.instruqt.com/hashicorp/tracks/multi-cloud-service-networking-with-consul'
 description: In this track you will set up a Consul shared service on AWS, and connect
   applications across multiple platforms.
-icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/consul.png
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/consul.png
 tags: []
 owner: hashicorp
 developers:

--- a/instruqt-tracks/consul-life-of-a-developer/track.yml
+++ b/instruqt-tracks/consul-life-of-a-developer/track.yml
@@ -4,7 +4,7 @@ type: track
 title: 'Consul: Life of a Developer'
 teaser: Build, Test, and Deploy Applications with HashiCorp Consul.
 description: Ship a new version of the HashiCups App on container runtimes.
-icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/consul.png
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/consul.png
 tags: []
 owner: hashicorp
 developers:

--- a/instruqt-tracks/hcs-on-azure/track.yml
+++ b/instruqt-tracks/hcs-on-azure/track.yml
@@ -6,7 +6,7 @@ title: 'DEPRECATED: HCS on Azure'
 teaser: 'See link for new track: https://play.instruqt.com/hashicorp/tracks/multi-cloud-service-networking-with-consul'
 description: Connect containerized and non-containerized workloads with the HashiCorp
   Consul Service on Azure
-icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/consul.png
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/consul.png
 tags:
 - hcs
 - consul

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/track.yml
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/track.yml
@@ -4,7 +4,7 @@ type: track
 title: Multi Cloud Service Networking with Consul
 teaser: Deploy a multi-cloud service mesh solution with Consul
 description: Run a shared Consul service across multiple clouds and enable self-service for application teams.
-icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/consul.png
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/consul.png
 tags:
 - consul
 - vault

--- a/instruqt-tracks/service-discovery-with-consul/track.yml
+++ b/instruqt-tracks/service-discovery-with-consul/track.yml
@@ -5,7 +5,7 @@ title: Service Discovery with Consul
 teaser: Tired of manually updating IP addresses in config files? Is your network CMDB or spreadsheet woefully out of date? Learn how Consul can automatically keep your service catalog up to date and current.
 description: |
   Join us on an adventure of service discovery. In this track you'll learn how to connect a web application with its database using Consul. Topics covered include service registration, health checks, service discovery, automated config management, and seamless DNS integration.
-icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/consul.png
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/consul.png
 tags:
 - service discovery
 - health checks

--- a/instruqt-tracks/service-mesh-with-consul-hybrid/track.yml
+++ b/instruqt-tracks/service-mesh-with-consul-hybrid/track.yml
@@ -5,7 +5,7 @@ title: Service Mesh with Consul Hybrid
 teaser: Connect disparate platforms across datacenters.
 description: In this track you leverage Mesh Gateways to connect applications and
   services between K8s and VMs in remote datacenters.
-icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/consul.png
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/consul.png
 tags: []
 owner: hashicorp
 developers:

--- a/instruqt-tracks/service-mesh-with-consul-k8s/track.yml
+++ b/instruqt-tracks/service-mesh-with-consul-k8s/track.yml
@@ -8,7 +8,7 @@ description: |-
   for service mesh.
 
   You'll work through scaling, monitoring, and tracing applications. To complete the track you, will gain experience with the advanced L7 traffic patterns.
-icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/consul.png
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/consul.png
 tags: []
 owner: hashicorp
 developers:

--- a/instruqt-tracks/service-mesh-with-consul/track.yml
+++ b/instruqt-tracks/service-mesh-with-consul/track.yml
@@ -6,7 +6,7 @@ teaser: Evolve from service discovery to service mesh. No more mapping IP addres
 description: |-
   This track will build on what you learned in the service discovery track and take our application from service discovery to service mesh.
   We'll dive into mesh fundamentals and use an Envoy proxy to connect our application to its database.
-icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/consul.png
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/consul.png
 tags: []
 owner: hashicorp
 developers:


### PR DESCRIPTION
Move consul icon from an Instruqt-owned GCP project to the HashiCorp-owned instruqt-hashicorp project.