### PR TITLE
clarifying tproxy for ingress controller

### DIFF
--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/track.yml
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/track.yml
@@ -1319,7 +1319,7 @@ challenges:
     kubectl apply -f k8s/public-api
     ```
 
-    Deploy the React Frontend. This frontend will be exposed via an ingress controller with a Connect transparent proxy. <br>
+    Deploy the React Frontend. This frontend will be exposed via an ingress controller that is configured with a Connect transparent proxy. <br>
 
     ```
     kubectl config use-context react


### PR DESCRIPTION
clarifying  set up that it is the ingress controller configured with tproxy to transparently send traffic to the services in the service mesh