### PR TITLE
policy change  - Name of node in policy for ACL

### DIFF
--- a/instruqt-tracks/consul-basics/06-consul-acls/setup-consul-agent-0
+++ b/instruqt-tracks/consul-basics/06-consul-acls/setup-consul-agent-0
@@ -25,7 +25,7 @@ EOF
 
 cat <<-EOF > /consul/policies/app.hcl
 # app.hcl
-node "App" {
+node "Application" {
   policy = "write"
 }
 EOF

--- a/instruqt-tracks/consul-basics/06-consul-acls/setup-consul-server-0
+++ b/instruqt-tracks/consul-basics/06-consul-acls/setup-consul-server-0
@@ -25,7 +25,7 @@ EOF
 
 cat <<-EOF > /consul/policies/app.hcl
 # app.hcl
-node "App" {
+node "Application" {
   policy = "write"
 }
 EOF

--- a/instruqt-tracks/consul-basics/06-consul-acls/setup-consul-server-1
+++ b/instruqt-tracks/consul-basics/06-consul-acls/setup-consul-server-1
@@ -25,7 +25,7 @@ EOF
 
 cat <<-EOF > /consul/policies/app.hcl
 # app.hcl
-node "App" {
+node "Application" {
   policy = "write"
 }
 EOF

--- a/instruqt-tracks/consul-basics/06-consul-acls/setup-consul-server-2
+++ b/instruqt-tracks/consul-basics/06-consul-acls/setup-consul-server-2
@@ -25,7 +25,7 @@ EOF
 
 cat <<-EOF > /consul/policies/app.hcl
 # app.hcl
-node "App" {
+node "Application" {
   policy = "write"
 }
 EOF

--- a/instruqt-tracks/consul-basics/track.yml
+++ b/instruqt-tracks/consul-basics/track.yml
@@ -341,7 +341,7 @@ challenges:
 
     ```
     consul acl token create -description "app agent token" \
-      -policy-name app
+      -policy-name application
     ```
 
     Finally apply the token to make it active.


### PR DESCRIPTION
When doing the acl step the policy for the node says App while the node is called application. That will make this step fail