### PR TITLE
output 3rd element from jq instead of 2nd to show SNI information.  This changed after adding tproxy.

### DIFF
--- a/instruqt-tracks/consul-life-of-a-developer/08-service-mesh-test-your-application/assignment.md
+++ b/instruqt-tracks/consul-life-of-a-developer/08-service-mesh-test-your-application/assignment.md
@@ -65,7 +65,7 @@ The gateway will inspect the SNI headers and forward it along to the correct des
 Inspect the SNI value for this service now. <br>
 
 ```
-kubectl exec deploy/payments-api-v1 -c envoy-sidecar -- wget -qO- 127.0.0.1:19000/config_dump | jq '[.. |."dynamic_active_clusters"? | select(. != null)[1]]'
+kubectl exec deploy/payments-api-v1 -c envoy-sidecar -- wget -qO- 127.0.0.1:19000/config_dump | jq '[.. |."dynamic_active_clusters"? | select(. != null)[2]]'
 ```
 
 Now that you understand the internals of the cross cluster routing, let's test the application so you can make sure it works. <br>


### PR DESCRIPTION
when we are inspecting the payments-api SNI header doesn’t show the actual SNI header.
root@workstation:~# kubectl exec deploy/payments-api-v1 -c envoy-sidecar -- wget -qO- 127.0.0.1:19000/config_dump | jq '[.. |."dynamic_active_clusters"? | select(. != null)[1]]'
[
  {
    "version_info": "dcd8d0247ba0149bfdc151428353b3f29d0665bf5c12af6a105a0abcc5af40ac",
    "cluster": {
      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
      "name": "original-destination",
      "type": "ORIGINAL_DST",
      "connect_timeout": "5s",
      "lb_policy": "CLUSTER_PROVIDED"
    },
    "last_updated": "2022-03-21T18:26:40.732Z"
  }
]
I’m not sure if something changed in our config or envoy.  If I update the command to show the second item in the list everything appears to work.
kubectl exec deploy/payments-api-v1 -c envoy-sidecar -- wget -qO- 127.0.0.1:19000/config_dump | jq '[.. |."dynamic_active_clusters"? | select(. != null)[2]]'