### PR TITLE
Set correct Azure region to US WEST, not US WEST 1

### DIFF
--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/infra/azure.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/infra/azure.tf
@@ -1,6 +1,6 @@
 resource "azurerm_resource_group" "instruqt" {
   name     = "instruqt-${random_string.env.result}"
-  location = "West US 1"
+  location = "West US"
 }
 
 module "azure-shared-svcs-network" {


### PR DESCRIPTION
location = "West US 1" bad. 
location = "West US" good