### PR TITLE
IL-378 Remove KUBERNETES_* vars to fix `kubectl` errors

### DIFF
--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/09-provision-gcp-consul-secondary-datacenter/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/09-provision-gcp-consul-secondary-datacenter/solve-cloud-client
@@ -6,6 +6,9 @@ terraform apply -auto-approve 2>&1 | tee terraform.out
 
 sleep 15
 
+# IL-378
+for kubevar in $(env | awk -F=  '/^KUBERNETES_/ { print $1;};'); do unset $kubevar; done
+
 #helm config
 gcloud container clusters get-credentials \
   $(terraform output -state /root/terraform/gcp-consul-secondary/terraform.tfstate gcp_gke_cluster_shared_name) \

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/track.yml
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/track.yml
@@ -16,6 +16,7 @@ owner: hashicorp
 developers:
 - lance@hashicorp.com
 - hari@hashicorp.com
+- thomas@hashicorp.com
 private: true
 published: true
 show_timer: true

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
@@ -29,6 +29,10 @@ cp -r field-workshops-consul/instruqt-tracks/multi-cloud-service-networking-with
 cp -r field-workshops-consul/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/scripts .
 rm -rf field-workshops-consul
 
+# IL-378
+# This looks weird Because Quoting(TM)
+echo 'for kubevar in $(env | awk -F=  '"'"'/^KUBERNETES_/ { print $1;};'"'"'); do unset $kubevar; done' >> /root/.bashrc
+
 # Ensure we load /etc/profile.d/instruqt-env.sh
 echo "source /etc/profile.d/instruqt-env.sh" >> /root/.bashrc
 source /root/.bashrc


### PR DESCRIPTION
When both KUBERNETES_* vars are set and
/run/secrets/kubernetes.io/serviceaccount/namspace exist `kubectl`
assumes you want to run it using the pod's ServiceAccount
credentials and in the namespace the pod is running. We don't want
to do that, we want to explicitly use the credentials and setup
in ~/.kube/config, so delete the environment variables (we cannot
remove the /run/secrets/... file because it's mounted readonly,
and Instruqt doesn't give us the option to not have those mounted
in)

Fixes https://hashicorp.atlassian.net/browse/IL-378