### PR TITLE
Fixes warning on NIA workshop for random_string

### DIFF
--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/vnet/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/vnet/main.tf
@@ -4,10 +4,10 @@ provider "azurerm" {
 }
 
 resource "random_string" "participant" {
-  length  = 4
-  special = false
-  upper   = false
-  number  = false
+  length   = 4
+  special  = false
+  upper    = false
+  numeric  = false
 }
 
 resource "azurerm_resource_group" "instruqt" {


### PR DESCRIPTION
The terraform code emits a warning due to:

```
on main.tf line 10, in resource "random_string" "participant":
  10:   number  = false

**NOTE**: This is deprecated, use `numeric` instead.
```