### PR TITLE
IL-477 Add additional logging and robustness to Multi-Cloud

### DIFF
--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/01-provision-cloud-infra/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/01-provision-cloud-infra/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #check images
 echo "Checking Packer Azure VM"

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/01-provision-cloud-infra/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/01-provision-cloud-infra/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #tf
 set-workdir /root/terraform/infra

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/01-provision-cloud-infra/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/01-provision-cloud-infra/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #tf
 #terraform apply -auto-approve 2>&1 | tee terraform.out

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/02-provision-vault/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/02-provision-vault/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #aws
 vault_lb=$(terraform output -state /root/terraform/vault/terraform.tfstate aws_vault_ip)

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/02-provision-vault/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/02-provision-vault/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #tf
 set-workdir /root/terraform/vault

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/02-provision-vault/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/02-provision-vault/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #tf
 terraform apply -auto-approve 2>&1 | tee terraform.out

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/03-provision-identities/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/03-provision-identities/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #check aws roles
 aws iam get-role --role-name consul-$(terraform output -state /root/terraform/infra/terraform.tfstate env)

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/03-provision-identities/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/03-provision-identities/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #tf
 set-workdir /root/terraform/iam

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/03-provision-identities/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/03-provision-identities/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #tf
 terraform apply -auto-approve 2>&1 | tee terraform.out

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/04-centralize-secrets-in-vault/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/04-centralize-secrets-in-vault/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #login
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/04-centralize-secrets-in-vault/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/04-centralize-secrets-in-vault/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 cd /root/terraform/vault
 set-workdir /root/terraform/vault

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/04-centralize-secrets-in-vault/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/04-centralize-secrets-in-vault/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #login
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/05-provision-aws-consul-primary/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/05-provision-aws-consul-primary/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 vault login -method=userpass username=admin password=admin
 export CONSUL_HTTP_TOKEN=$(vault kv get -field master_token kv/consul)

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/05-provision-aws-consul-primary/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/05-provision-aws-consul-primary/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 cd /root/terraform/aws-consul-primary
 terraform init

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/05-provision-aws-consul-primary/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/05-provision-aws-consul-primary/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 terraform apply -auto-approve 2>&1 | tee terraform.out
 sleep 120

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/06-bootstrap-consul-primary/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/06-bootstrap-consul-primary/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/06-bootstrap-consul-primary/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/06-bootstrap-consul-primary/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #ui access
 consul_lb=$(terraform output -state /root/terraform/aws-consul-primary/terraform.tfstate aws_consul_public_ip)

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/06-bootstrap-consul-primary/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/06-bootstrap-consul-primary/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #aws
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/07-create-namespaces-and-policies/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/07-create-namespaces-and-policies/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/07-create-namespaces-and-policies/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/07-create-namespaces-and-policies/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 set-workdir /root/policies/consul
 

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/07-create-namespaces-and-policies/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/07-create-namespaces-and-policies/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 vault login -method=userpass username=admin password=admin
 export CONSUL_HTTP_TOKEN=$(vault read -field token consul/creds/operator)

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/08-provision-azure-consul-secondary-datacenter/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/08-provision-azure-consul-secondary-datacenter/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #azure - server
 consul_lb=$(terraform output -state /root/terraform/azure-consul-secondary/terraform.tfstate azure_consul_public_ip)

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/08-provision-azure-consul-secondary-datacenter/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/08-provision-azure-consul-secondary-datacenter/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 cd /root/terraform/azure-consul-secondary
 terraform init

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/08-provision-azure-consul-secondary-datacenter/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/08-provision-azure-consul-secondary-datacenter/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 terraform apply -auto-approve 2>&1 | tee terraform.out
 sleep 300

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/09-provision-gcp-consul-secondary-datacenter/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/09-provision-gcp-consul-secondary-datacenter/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 kubectl config use-context shared
 status=$(helm status hashicorp --output json | jq -r '.info.status')

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/09-provision-gcp-consul-secondary-datacenter/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/09-provision-gcp-consul-secondary-datacenter/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #dir
 set-workdir /root/terraform/gcp-consul-secondary

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/09-provision-gcp-consul-secondary-datacenter/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/09-provision-gcp-consul-secondary-datacenter/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #provision K8s clusters
 export GOOGLE_CREDENTIALS=$(echo $INSTRUQT_GCP_PROJECT_CONSUL_SERVICE_ACCOUNT_KEY | base64 -d)

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/10-automate-security-groups-with-cts/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/10-automate-security-groups-with-cts/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/10-automate-security-groups-with-cts/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/10-automate-security-groups-with-cts/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 
 #!/bin/bash

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/10-automate-security-groups-with-cts/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/10-automate-security-groups-with-cts/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/11-provision-consul-esms/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/11-provision-consul-esms/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/11-provision-consul-esms/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/11-provision-consul-esms/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 cd /root/terraform/esm
 terraform init

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/11-provision-consul-esms/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/11-provision-consul-esms/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/12-provision-cache-services/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/12-provision-cache-services/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/12-provision-cache-services/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/12-provision-cache-services/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 cd /root/terraform/cache-services
 terraform init

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/12-provision-cache-services/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/12-provision-cache-services/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/13-provision-database-services/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/13-provision-database-services/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/13-provision-database-services/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/13-provision-database-services/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 cd /root/terraform/database-services
 terraform init

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/13-provision-database-services/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/13-provision-database-services/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/14-provision-consul-terminating-gateways/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/14-provision-consul-terminating-gateways/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/14-provision-consul-terminating-gateways/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/14-provision-consul-terminating-gateways/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #tgw
 cd /root/terraform/tgw

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/14-provision-consul-terminating-gateways/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/14-provision-consul-terminating-gateways/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/15-provision-nomad-scheduler-services/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/15-provision-nomad-scheduler-services/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/15-provision-nomad-scheduler-services/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/15-provision-nomad-scheduler-services/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 cd /root/terraform/nomad-scheduler-services
 terraform init

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/15-provision-nomad-scheduler-services/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/15-provision-nomad-scheduler-services/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 terraform apply -auto-approve 2>&1 | tee terraform.out
 sleep 120

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/16-provision-k8s-scheduler-services/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/16-provision-k8s-scheduler-services/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 kubectl config use-context graphql
 status=$(helm status consul --output json | jq -r '.info.status')

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/16-provision-k8s-scheduler-services/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/16-provision-k8s-scheduler-services/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 set-workdir /root/terraform/k8s-scheduler-services
 

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/16-provision-k8s-scheduler-services/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/16-provision-k8s-scheduler-services/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #provision k8s
 cd /root/terraform/k8s-scheduler-services

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/17-configure-intentions/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/17-configure-intentions/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/17-configure-intentions/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/17-configure-intentions/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 vault login -method=userpass username=admin password=admin
 export CONSUL_HTTP_TOKEN=$(vault kv get -field master_token kv/consul)

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/17-configure-intentions/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/17-configure-intentions/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 
 #default

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/18-deploy-payments-applications/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/18-deploy-payments-applications/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/18-deploy-payments-applications/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/18-deploy-payments-applications/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 set-workdir /root/apps/nomad
 

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/18-deploy-payments-applications/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/18-deploy-payments-applications/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 nomad run /root/apps/nomad/payments-api.hcl
 sleep 90

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/19-deploy-product-applications/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/19-deploy-product-applications/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/19-deploy-product-applications/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/19-deploy-product-applications/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 cd /root/terraform/product-applications
 terraform init

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/19-deploy-product-applications/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/19-deploy-product-applications/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 terraform apply -auto-approve 2>&1 | tee terraform.out
 sleep 120

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/20-deploy-frontend-applications/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/20-deploy-frontend-applications/check-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #creds
 vault login -method=userpass username=admin password=admin

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/20-deploy-frontend-applications/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/20-deploy-frontend-applications/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #dir
 set-workdir /root/apps

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/20-deploy-frontend-applications/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/20-deploy-frontend-applications/solve-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 kubectl config use-context graphql
 kubectl apply -f k8s/public-api

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/21-review-application-deployment/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/21-review-application-deployment/solve-cloud-client
@@ -1,16 +1,35 @@
 #!/bin/bash
+set -euvxo pipefail
 
 #check db
-export PGPASSWORD=$(terraform output -state /root/terraform/database-services/terraform.tfstate postgres_password)
-psql -U postgres@$(terraform output -state /root/terraform/infra/terraform.tfstate env) \
-  -d postgres \
-  -h $(terraform output -state /root/terraform/database-services/terraform.tfstate postgres_fqdn) \
-  -c 'SELECT * FROM coffees' \
-  -a
+n=0
+until [ $n -ge 5 ]; do
+    export PGPASSWORD=$(terraform output -state /root/terraform/database-services/terraform.tfstate postgres_password)
+    psql -U postgres \
+      -d postgres \
+      -h $(terraform output -state /root/terraform/database-services/terraform.tfstate postgres_fqdn) \
+      -c 'SELECT * FROM coffees' \
+      -a && break
+    n=$[$n+1]
+    sleep 20
+done
+if [ $n -ge 5 ]; then
+    echo "Postgres fails"
+    exit 1
+fi
 
 #check queue
-ssh -i ~/.ssh/id_rsa ubuntu@$(terraform output -state /root/terraform/tgw/terraform.tfstate aws_tgw_public_ip) \
-  "redis-cli -h \
-  $(terraform output -state /root/terraform/cache-services/terraform.tfstate -json aws_elasticache_cache_nodes | jq -r .[0].address) -p 6379 keys '*'"
+n=0
+until [ $n -ge 5 ]; do
+    ssh -i ~/.ssh/id_rsa ubuntu@$(terraform output -state /root/terraform/tgw/terraform.tfstate aws_tgw_public_ip) \
+      "redis-cli -h \
+      $(terraform output -state /root/terraform/cache-services/terraform.tfstate -json aws_elasticache_cache_nodes | jq -r .[0].address) -p 6379 keys '*'" && break
+    n=$[$n+1]
+    sleep 20
+done
+if [ $n -ge 5 ]; then
+    echo "queue check fails"
+    exit 1
+fi
 
 exit 0

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/22-test-application-deployment/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/22-test-application-deployment/check-cloud-client
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euvxo pipefail
 
 #Frontend Nginx TProxy Endpoint
 kubectl config use-context react

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/22-test-application-deployment/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/22-test-application-deployment/setup-cloud-client
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euvxo pipefail
 
 kubectl config use-context react
 frontend_endpoint=$(kubectl get svc nginx-ingress-controller -o json | jq -r .status.loadBalancer.ingress[0].ip)

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/22-test-application-deployment/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/22-test-application-deployment/solve-cloud-client
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -euvxo pipefail
 
 #ui
 kubectl config use-context react
@@ -16,7 +17,7 @@ curl -s -v http://${endpoint}:8080/api \
   -H 'Connection: keep-alive' \
   -H 'DNT: 1' \
   --data-binary '{"query":"{\n  coffees{id,name,price}\n}"}' \
-  --compressed | jq
+  --compressed | jq .
 
 #payments
 curl -s -v http://${endpoint}:8080/api \
@@ -26,6 +27,6 @@ curl -s -v http://${endpoint}:8080/api \
   -H 'Connection: keep-alive' \
   -H 'DNT: 1' \
   --data-binary '{"query":"mutation{ pay(details:{ name: \"nic\", type: \"mastercard\", number: \"1234123-0123123\", expiry:\"10/02\", cv2: 1231, amount: 12.23 }){id, card_plaintext, card_ciphertext, message } }"}' \
-  --compressed | jq
+  --compressed | jq .
 
 exit 0

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/23-observe-application-deployment/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/23-observe-application-deployment/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 set-workdir /root/terraform/monitoring
 
@@ -43,7 +44,7 @@ curl -s -v http://${endpoint}:8080/api \
   -H 'Connection: keep-alive' \
   -H 'DNT: 1' \
   --data-binary '{"query":"{\n  coffees{id,name,price}\n}"}' \
-  --compressed | jq
+  --compressed | jq .
 #payment api
 curl -s -v http://${endpoint}:8080/api \
   -H 'Accept-Encoding: gzip, deflate, br' \
@@ -52,6 +53,6 @@ curl -s -v http://${endpoint}:8080/api \
   -H 'Connection: keep-alive' \
   -H 'DNT: 1' \
   --data-binary '{"query":"mutation{ pay(details:{ name: \"nic\", type: \"mastercard\", number: \"1234123-0123123\", expiry:\"10/02\", cv2: 1231, amount: 12.23 }){id, card_plaintext, card_ciphertext, message } }"}' \
-  --compressed | jq
+  --compressed | jq .
 
 exit 0

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euvxo pipefail
 
 # Note: override these when testing from a different repo and/or branch
 #       The `-b` option to `git clone` is useful for pulling from the
@@ -8,6 +9,8 @@ ASSET_REPO="https://github.com/hashicorp/field-workshops-consul.git"
 ASSET_REPO_FETCH_OPTIONS=""
 
 # END OPTIONS
+
+echo "##### INSTRUQT PARTICIPANT ID ${INSTRUQT_PARTICIPANT_ID}"
 
 #make vault run in instruqt container
 setcap cap_ipc_lock= /usr/bin/vault


### PR DESCRIPTION
* Improve debugging by adding `set -euvxo pipefail` per Instruqt recommendations
* Switch some scripts to `/bin/bash` to accomplish the above
* Change usage of `| jq` to `| jq .` so jq doesn't fail (and thus trigger script failure)
* In track 21 loop in `solve-cloud-client` because Azure lies (we also loop in the queue check to be consistent)
* In track 21 the postgres username is `postgres`, not `postgres@{env}` (this previously didn't cause the script to fail, although it would log an error; now with `set -e` the script fails)