### PR TITLE
IL-493 pin Azure/network/azurerm to 3.5.0 in NIA and Multi-Cloud Workshops

### DIFF
--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/infra/azure.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/infra/azure.tf
@@ -5,6 +5,7 @@ resource "azurerm_resource_group" "instruqt" {
 
 module "azure-shared-svcs-network" {
   source              = "Azure/network/azurerm"
+  version             = "3.5.0"
   vnet_name           = "shared-svcs-vnet"
   resource_group_name = azurerm_resource_group.instruqt.name
   address_space       = "10.1.0.0/16"
@@ -18,6 +19,7 @@ module "azure-shared-svcs-network" {
 
 module "azure-app-network" {
   source              = "Azure/network/azurerm"
+  version             = "3.5.0"
   resource_group_name = azurerm_resource_group.instruqt.name
   vnet_name           = "app-vnet"
   address_space       = "10.2.0.0/16"

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
@@ -6,7 +6,7 @@ set -euvxo pipefail
 #       non-default branch
 
 ASSET_REPO="https://github.com/hashicorp/field-workshops-consul.git"
-ASSET_REPO_FETCH_OPTIONS=""
+ASSET_REPO_FETCH_OPTIONS="-b IL-493"
 
 # END OPTIONS
 

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
@@ -6,7 +6,7 @@ set -euvxo pipefail
 #       non-default branch
 
 ASSET_REPO="https://github.com/hashicorp/field-workshops-consul.git"
-ASSET_REPO_FETCH_OPTIONS="-b IL-493"
+ASSET_REPO_FETCH_OPTIONS=""
 
 # END OPTIONS
 

--- a/instruqt-tracks/network-infrastructure-automation/8-install-consul-terraform-sync/solve-workstation
+++ b/instruqt-tracks/network-infrastructure-automation/8-install-consul-terraform-sync/solve-workstation
@@ -8,6 +8,33 @@ echo ">>"
 cd /root/terraform/consul-tf-sync
 terraform apply -auto-approve > /root/terraform/consul-tf-sync/terraform.out
 
-sleep 90
+# Wait until things are actually set up
+n=0
+until [ $n -ge 20 ]; do
+    echo "Try ${n}"
+    rg=$(terraform output -state /root/terraform/vnet/terraform.tfstate resource_group_name)
+    echo "Checking consul-terraform-sync instance in resource group $rg:"
+    status=$(az vm get-instance-view -g $rg --name consul-terraform-sync | jq -r .provisioningState)
+    echo $status
+
+    if [ "${status}" != "Creating" ] && [ "${status}" != "Updating" ] && [ "${status}" != "Succeeded" ] ; then
+      echo "consul-terraform-sync instance is not provisioned. Wait a few moments and try again. Current state is: ${status}"
+      sleep 60
+      n=$[$n+1]
+      continue
+    fi
+
+    #check the app works
+    app=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080)
+    if [ "${app}" != "200" ]; then
+      echo "App did not return a 200, returned ${app}"
+      n=$[$n+1]
+      sleep 60
+      continue
+    fi
+
+    break
+done
+
 
 exit 0

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/vnet/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/vnet/main.tf
@@ -17,6 +17,7 @@ resource "azurerm_resource_group" "instruqt" {
 
 module "shared-svcs-network" {
   source              = "Azure/network/azurerm"
+  version             = "3.5.0"
   vnet_name           = "shared-svcs-vnet"
   resource_group_name = azurerm_resource_group.instruqt.name
   address_space       = "10.2.0.0/16"
@@ -30,6 +31,7 @@ module "shared-svcs-network" {
 
 module "app-network" {
   source              = "Azure/network/azurerm"
+  version             = "3.5.0"
   resource_group_name = azurerm_resource_group.instruqt.name
   vnet_name           = "app-vnet"
   address_space       = "10.3.0.0/16"

--- a/instruqt-tracks/network-infrastructure-automation/track.yml
+++ b/instruqt-tracks/network-infrastructure-automation/track.yml
@@ -1,7 +1,8 @@
-slug: zzz-thomas-il-493-network-infrastructure-automation-update
+slug: network-infrastructure-automation
+id: zd9iqr8wyub0
 version: 0.0.1
 type: track
-title: ZZZ Thomas IL-493 Network Infrastructure Automation - Update
+title: Network Infrastructure Automation - Update
 teaser: Automate the provisioning and ongoing management of network infrastructure.
 description: In this workshop you'll learn how to automate the provisioning and management
   of traditional network infrastructure using Terraform, Consul, and Consul Terraform
@@ -16,12 +17,14 @@ developers:
 - lance@hashicorp.com
 - npearce@hashicorp.com
 - raj@hashicorp.com
+- thomas@hashicorp.com
 private: true
 published: true
 show_timer: true
 skipping_enabled: true
 challenges:
 - slug: 1-review-lab-objectives
+  id: xuq4qb0mo9v1
   type: challenge
   title: Review Lab Objectives
   teaser: Before we begin, lets quickly review the architecture.
@@ -64,6 +67,7 @@ challenges:
   difficulty: basic
   timelimit: 300
 - slug: 2-provision-azure-vnets
+  id: dwo2s5mw6ona
   type: challenge
   title: Provision Azure VNETs
   teaser: Deploy basic network infrastructure using Terraform
@@ -118,6 +122,7 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 3-provision-core-services
+  id: dlsjgdoiu2ua
   type: challenge
   title: Provision Core Services
   teaser: Provision Vault and Consul using Terraform
@@ -175,6 +180,7 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 4-provision-network-infra
+  id: qm7eoyy10e00
   type: challenge
   title: Provision F5 BIG-IP & Palo Alto Firewall
   teaser: Provision an F5 BIG-IP VE & Palo Alto Firewall using Terraform
@@ -233,6 +239,7 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 5-configure-palo-alto-firewall
+  id: 7vltkulroiy8
   type: challenge
   title: Configure Palo Alto Firewall
   teaser: Provision a Palo Alto VM-Series Firewall using Terraform.
@@ -288,6 +295,7 @@ challenges:
   difficulty: basic
   timelimit: 300
 - slug: 6-validate-vault
+  id: l6orpveiedpr
   type: challenge
   title: Validate Vault & Consul
   teaser: Verify Vault, and Consul are operational
@@ -345,6 +353,7 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 7-deploy-app-environments
+  id: wvgbbfknw4fz
   type: challenge
   title: Deploy App environments
   teaser: Deploy a 2-tier VM based application to the cloud.
@@ -406,6 +415,7 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 8-install-consul-terraform-sync
+  id: 4pa4nyish9os
   type: challenge
   title: Deploy 'Consul Terraform Sync'
   teaser: Now we are going install Consul Terraform Sync and bring dynamic service
@@ -499,6 +509,7 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 9-scale-the-application
+  id: 7ffmbpmxzn1p
   type: challenge
   title: Scale the application
   teaser: Let Consul take care of routine adds/moves/changes of services instances.
@@ -595,3 +606,4 @@ challenges:
     port: 80
   difficulty: basic
   timelimit: 3000
+checksum: "14590901449097205310"

--- a/instruqt-tracks/network-infrastructure-automation/track.yml
+++ b/instruqt-tracks/network-infrastructure-automation/track.yml
@@ -1,8 +1,7 @@
-slug: network-infrastructure-automation
-id: zd9iqr8wyub0
+slug: zzz-thomas-il-493-network-infrastructure-automation-update
 version: 0.0.1
 type: track
-title: Network Infrastructure Automation - Update
+title: ZZZ Thomas IL-493 Network Infrastructure Automation - Update
 teaser: Automate the provisioning and ongoing management of network infrastructure.
 description: In this workshop you'll learn how to automate the provisioning and management
   of traditional network infrastructure using Terraform, Consul, and Consul Terraform
@@ -23,7 +22,6 @@ show_timer: true
 skipping_enabled: true
 challenges:
 - slug: 1-review-lab-objectives
-  id: xuq4qb0mo9v1
   type: challenge
   title: Review Lab Objectives
   teaser: Before we begin, lets quickly review the architecture.
@@ -66,7 +64,6 @@ challenges:
   difficulty: basic
   timelimit: 300
 - slug: 2-provision-azure-vnets
-  id: dwo2s5mw6ona
   type: challenge
   title: Provision Azure VNETs
   teaser: Deploy basic network infrastructure using Terraform
@@ -121,7 +118,6 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 3-provision-core-services
-  id: dlsjgdoiu2ua
   type: challenge
   title: Provision Core Services
   teaser: Provision Vault and Consul using Terraform
@@ -179,7 +175,6 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 4-provision-network-infra
-  id: qm7eoyy10e00
   type: challenge
   title: Provision F5 BIG-IP & Palo Alto Firewall
   teaser: Provision an F5 BIG-IP VE & Palo Alto Firewall using Terraform
@@ -238,7 +233,6 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 5-configure-palo-alto-firewall
-  id: 7vltkulroiy8
   type: challenge
   title: Configure Palo Alto Firewall
   teaser: Provision a Palo Alto VM-Series Firewall using Terraform.
@@ -294,7 +288,6 @@ challenges:
   difficulty: basic
   timelimit: 300
 - slug: 6-validate-vault
-  id: l6orpveiedpr
   type: challenge
   title: Validate Vault & Consul
   teaser: Verify Vault, and Consul are operational
@@ -352,7 +345,6 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 7-deploy-app-environments
-  id: wvgbbfknw4fz
   type: challenge
   title: Deploy App environments
   teaser: Deploy a 2-tier VM based application to the cloud.
@@ -414,7 +406,6 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 8-install-consul-terraform-sync
-  id: 4pa4nyish9os
   type: challenge
   title: Deploy 'Consul Terraform Sync'
   teaser: Now we are going install Consul Terraform Sync and bring dynamic service
@@ -508,7 +499,6 @@ challenges:
   difficulty: basic
   timelimit: 3000
 - slug: 9-scale-the-application
-  id: 7ffmbpmxzn1p
   type: challenge
   title: Scale the application
   teaser: Let Consul take care of routine adds/moves/changes of services instances.
@@ -605,4 +595,3 @@ challenges:
     port: 80
   difficulty: basic
   timelimit: 3000
-checksum: "14590901449097205310"

--- a/instruqt-tracks/network-infrastructure-automation/track_scripts/setup-workstation
+++ b/instruqt-tracks/network-infrastructure-automation/track_scripts/setup-workstation
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Note: override these when testing from a different repo and/or branch
+#       The `-b` option to `git clone` is useful for pulling from the
+#       non-default branch
+
+ASSET_REPO="https://github.com/hashicorp/field-workshops-consul.git"
+ASSET_REPO_FETCH_OPTIONS="-b IL-493"
+
+# END OPTIONS
+
 #azure creds
 sleep 30
 
@@ -41,7 +50,8 @@ fi
 
 #get assets
 echo "cloning assets..."
-git clone https://github.com/hashicorp/field-workshops-consul.git
+echo "git clone ${ASSET_REPO_FETCH_OPTIONS} ${ASSET_REPO}"
+git clone ${ASSET_REPO_FETCH_OPTIONS} ${ASSET_REPO}
 cp -r field-workshops-consul/instruqt-tracks/network-infrastructure-automation/assets/terraform /root/terraform
 rm -rf field-workshops-consul
 

--- a/instruqt-tracks/network-infrastructure-automation/track_scripts/setup-workstation
+++ b/instruqt-tracks/network-infrastructure-automation/track_scripts/setup-workstation
@@ -5,7 +5,7 @@
 #       non-default branch
 
 ASSET_REPO="https://github.com/hashicorp/field-workshops-consul.git"
-ASSET_REPO_FETCH_OPTIONS="-b IL-493"
+ASSET_REPO_FETCH_OPTIONS=""
 
 # END OPTIONS
 


### PR DESCRIPTION
The 4.0.0 and later versions, recently released, cause problems with the version of Terraform we have pinned in this tracks. Pin to 3.5.0 for now.