### PR TITLE
IL-495 Pin version of GKE Clusters

### DIFF
--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
@@ -17,6 +17,11 @@ resource "google_container_cluster" "shared" {
     }
   }
 
+  # IL-495
+  min_master_version = "1.21.14-gke.8500"
+  node_version       = "1.21.14-gke.8500"
+  # IL-495
+
   node_config {
     service_account = data.terraform_remote_state.iam.outputs.gcp_consul_service_account_email
     oauth_scopes = [

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
@@ -20,6 +20,19 @@ resource "google_container_cluster" "shared" {
   # IL-495
   min_master_version = "1.21.14-gke.8500"
   node_version       = "1.21.14-gke.8500"
+  # GKE mandates at least 48hr of maintenance window in a 32 day period.
+  # We don't want upgrades during a lab, so we use the below values.
+  # Choose two six-hour windows on Saturday and Sunday.
+  # The earliest maintenance would start would be on a Saturday at 3am
+  # in Honolulu, the latest would be Monday 4am in Tokyo, to pick locales
+  # roughly at either end of time zone offsets
+  maintenance_policy {
+    recurring_window {
+      start_time = "2022-12-11T13:00:00Z"
+      end_time   = "2022-12-11T19:00:00Z"
+      recurrence = "FREQ=WEEKLY;WKST=SU;BYDAY=SA,SU"
+    }
+  }
   # IL-495
 
   node_config {

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
@@ -20,6 +20,19 @@ resource "google_container_cluster" "graphql" {
   # IL-495
   min_master_version = "1.21.14-gke.8500"
   node_version       = "1.21.14-gke.8500"
+  # GKE mandates at least 48hr of maintenance window in a 32 day period.
+  # We don't want upgrades during a lab, so we use the below values.
+  # Choose two six-hour windows on Saturday and Sunday.
+  # The earliest maintenance would start would be on a Saturday at 3am
+  # in Honolulu, the latest would be Monday 4am in Tokyo, to pick locales
+  # roughly at either end of time zone offsets
+  maintenance_policy {
+    recurring_window {
+      start_time = "2022-12-11T13:00:00Z"
+      end_time   = "2022-12-11T19:00:00Z"
+      recurrence = "FREQ=WEEKLY;WKST=SU;BYDAY=SA,SU"
+    }
+  }
   # IL-495
 
   node_config {
@@ -66,6 +79,19 @@ resource "google_container_cluster" "react" {
   # IL-495
   min_master_version = "1.21.14-gke.8500"
   node_version       = "1.21.14-gke.8500"
+  # GKE mandates at least 48hr of maintenance window in a 32 day period.
+  # We don't want upgrades during a lab, so we use the below values.
+  # Choose two six-hour windows on Saturday and Sunday.
+  # The earliest maintenance would start would be on a Saturday at 3am
+  # in Honolulu, the latest would be Monday 4am in Tokyo, to pick locales
+  # roughly at either end of time zone offsets
+  maintenance_policy {
+    recurring_window {
+      start_time = "2022-12-11T13:00:00Z"
+      end_time   = "2022-12-11T19:00:00Z"
+      recurrence = "FREQ=WEEKLY;WKST=SU;BYDAY=SA,SU"
+    }
+  }
   # IL-495
 
   node_config {

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
@@ -17,6 +17,11 @@ resource "google_container_cluster" "graphql" {
     }
   }
 
+  # IL-495
+  min_master_version = "1.21.14-gke.8500"
+  node_version       = "1.21.14-gke.8500"
+  # IL-495
+
   node_config {
     service_account = data.terraform_remote_state.iam.outputs.gcp_consul_service_account_email
     oauth_scopes = [
@@ -57,6 +62,11 @@ resource "google_container_cluster" "react" {
       issue_client_certificate = false
     }
   }
+
+  # IL-495
+  min_master_version = "1.21.14-gke.8500"
+  node_version       = "1.21.14-gke.8500"
+  # IL-495
 
   node_config {
     service_account = data.terraform_remote_state.iam.outputs.gcp_consul_service_account_email


### PR DESCRIPTION
GKE now defaults to a cluster version which no longer works with the pinned version of the Helm chart we use. Defer upgrading the whole lot to a later issue and for now pin to a version we know works.