### PR TITLE
IL-552 switch Azure region to avoid excessively long VM creation times

### DIFF
--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/packer/hashistack.json
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/packer/hashistack.json
@@ -61,7 +61,7 @@
         "os-version": "bionic"
       },
       "location": "Central US",
-      "vm_size": "Standard_DS2_v2"
+      "vm_size": "Standard_DS3_v2"
     }
   ],
   "provisioners": [

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/packer/hashistack.json
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/packer/hashistack.json
@@ -60,8 +60,8 @@
         "os": "ubuntu",
         "os-version": "bionic"
       },
-      "location": "Central US",
-      "vm_size": "Standard_DS3_v2"
+      "location": "South Central US",
+      "vm_size": "Standard_DS2_v2"
     }
   ],
   "provisioners": [

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/packer/hashistack.json
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/packer/hashistack.json
@@ -60,7 +60,7 @@
         "os": "ubuntu",
         "os-version": "bionic"
       },
-      "location": "West US 3",
+      "location": "Central US",
       "vm_size": "Standard_DS2_v2"
     }
   ],

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/infra/azure.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/infra/azure.tf
@@ -3,7 +3,7 @@
 
 resource "azurerm_resource_group" "instruqt" {
   name     = "instruqt-${random_string.env.result}"
-  location = "West US 3"
+  location = "Central US"
 }
 
 module "azure-shared-svcs-network" {

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/infra/azure.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/infra/azure.tf
@@ -3,7 +3,7 @@
 
 resource "azurerm_resource_group" "instruqt" {
   name     = "instruqt-${random_string.env.result}"
-  location = "Central US"
+  location = "South Central US"
 }
 
 module "azure-shared-svcs-network" {

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/vault/azure.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/vault/azure.tf
@@ -111,7 +111,7 @@ resource "azurerm_virtual_machine" "vault" {
   location              = data.terraform_remote_state.infra.outputs.azure_rg_location
   resource_group_name   = data.terraform_remote_state.infra.outputs.azure_rg_name
   network_interface_ids = [azurerm_network_interface.vault.id]
-  vm_size               = "Standard_DS3_v2"
+  vm_size               = "Standard_DS2_v2"
 
   identity {
     type = "SystemAssigned"

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/vault/azure.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/vault/azure.tf
@@ -111,7 +111,7 @@ resource "azurerm_virtual_machine" "vault" {
   location              = data.terraform_remote_state.infra.outputs.azure_rg_location
   resource_group_name   = data.terraform_remote_state.infra.outputs.azure_rg_name
   network_interface_ids = [azurerm_network_interface.vault.id]
-  vm_size               = "Standard_DS2_v2"
+  vm_size               = "Standard_DS3_v2"
 
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
Azure VMs in "West US 3" were taking over 16 minutes to create, which was causing us to exceed the 30 minute time limit for `setup-` scripts. In "South Central US" same VM takes just under a minute to create.