### PR TITLE
IL-589 Pin version of Vault we install

### DIFF
--- a/instruqt-tracks/consul-life-of-a-developer/config.yml
+++ b/instruqt-tracks/consul-life-of-a-developer/config.yml
@@ -9,6 +9,7 @@ containers:
   environment:
     CONSUL_VERSION: 1.11.4
     CONSUL_HELM_VERSION: v0.41.1
+    VAULT_HELM_VERSION: v0.23.0
   ports:
   - 8500
   memory: 1024

--- a/instruqt-tracks/consul-life-of-a-developer/track_scripts/setup-workstation
+++ b/instruqt-tracks/consul-life-of-a-developer/track_scripts/setup-workstation
@@ -76,7 +76,7 @@ EOF
 #vault deploy
 /usr/sbin/setcap cap_ipc_lock= /usr/bin/vault
 kubectl config use-context k8s1
-/usr/local/bin/helm install vault hashicorp/vault -f /root/helm/vault-values.yaml
+/usr/local/bin/helm install vault hashicorp/vault -f /root/helm/vault-values.yaml --version $VAULT_HELM_VERSION
 sleep 60
 
 #vault config


### PR DESCRIPTION
The latest version of the Vault helm chart requires Kubernetes 1.22.0 or greater, we have 1.21. Pin the helm chart we install.