### PR TITLE
IL-586 Embed nomad-cluster-role.json

### DIFF
--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/policies/vault/nomad-cluster-role.json
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/policies/vault/nomad-cluster-role.json
@@ -1,0 +1,8 @@
+{
+  "disallowed_policies": "nomad-server",
+  "token_explicit_max_ttl": 0,
+  "name": "nomad-cluster",
+  "orphan": true,
+  "token_period": 259200,
+  "renewable": true
+}

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/scripts/setup_vault.sh
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/scripts/setup_vault.sh
@@ -60,7 +60,6 @@ vault policy write product-api product-api.hcl
 vault policy write payments-developer payments-developer.hcl
 vault policy write product-developer product-developer.hcl
 vault policy write frontend-developer frontend-developer.hcl
-curl  https://nomadproject.io/data/vault/nomad-cluster-role.json -O -s -L
 vault write /auth/token/roles/nomad-cluster @nomad-cluster-role.json
 
 #vault users - not for production


### PR DESCRIPTION
This temporarily disappeared from the Nomad website. They're restored it, but while we're at it let's remove an external dependency on something which hasn't changed for ages.