### PR TITLE
IL-609 Fix issue with challenge 05 and apache2 restarts

### DIFF
--- a/instruqt-tracks/service-mesh-with-consul/05-open-and-close-the-gates/setup-app
+++ b/instruqt-tracks/service-mesh-with-consul/05-open-and-close-the-gates/setup-app
@@ -2,6 +2,3 @@
 
 #create intention
 /usr/bin/consul intention create -deny * *
-
-#restart web server
-/usr/sbin/service apache2 restart

--- a/instruqt-tracks/service-mesh-with-consul/05-open-and-close-the-gates/solve-app
+++ b/instruqt-tracks/service-mesh-with-consul/05-open-and-close-the-gates/solve-app
@@ -2,9 +2,6 @@
 
 #create intention
 /usr/bin/consul intention create -allow wordpress mysql
-
-#restart web server
-/usr/sbin/service apache2 restart
-sleep 60
+sleep 10	# Allow intention to propagate
 
 exit 0

--- a/instruqt-tracks/service-mesh-with-consul/track.yml
+++ b/instruqt-tracks/service-mesh-with-consul/track.yml
@@ -82,10 +82,13 @@ challenges:
     consul reload
     ```
 
-    You should see a failing service called `mysql-sidecar-proxy` in Consul.
-    This is expected! <br>
+    You should see `mysql` as a failing service now in the Consul UI, and if
+    you click on that service, go to the `Instances` tab, and click on the
+    one instance of `mysql`, you will see that the `Connect Sidecar Listening`
+    health check is failing. This is expected. <br>
 
-    We will start a proxy and register it with Connect in our next challenge.
+    We will fix this by starting a proxy and registering it with Connect in
+    our next challenge.
   tabs:
   - title: Consul UI
     type: service
@@ -132,7 +135,7 @@ challenges:
     nohup consul connect envoy -sidecar-for mysql > /envoy.out &
     ```
 
-    You can verify in the Consul UI or the with the Consul CLI that your proxy health check is now passing. <br>
+    You can verify in the Consul UI or the with the Consul CLI that all of the 'mysql' health checks are now passing. <br>
 
     We can now use the proxy to establish communication between our application and the database!
   tabs:


### PR DESCRIPTION
We don't need apache2 restarts, and it appears the first time you restart apache2 it fails for some reason I cannot figure out at this point. Removed them since we don't need them.

Took the opportunity to clarify a couple of the challenge instructions while I was at it.