### PR TITLE
IL-613 Fixes to Multi-Cloud Workshop

### DIFF
--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/14-provision-consul-terminating-gateways/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/14-provision-consul-terminating-gateways/solve-cloud-client
@@ -12,6 +12,91 @@ consul acl policy create -name azure-terminating-gateway -rules @/root/policies/
 vault write consul/roles/azure-tgw policies=azure-terminating-gateway
 cd /root/terraform/tgw
 terraform apply -auto-approve 2>&1 | tee terraform.out
-sleep 120
+
+# IL-613
+# Wait until services are up and running
+
+n=1
+while /bin/true; do
+    echo "Checking aws tgw token, loop ${n}"
+    output=$(vault read consul/creds/aws-tgw 2>&1)
+    rc=$?
+    if [ $rc -ne 0 ]
+    then
+      echo "Error checking Consul AWS TGW acl token, return code ${rc}: ${output}"
+      sleep 10
+      n=$(( n + 1 ))
+    else
+      # If we get here, we were successful
+      break
+    fi
+done
+
+
+n=1
+while /bin/true; do
+    echo "Checking azure tgw token, loop ${n}"
+    output=$(vault read consul/creds/azure-tgw 2>&1)
+    rc=$?
+    if [ $rc -ne 0 ]
+    then
+      echo "Error checking Consul Azure TGW acl token, return code ${rc}: ${output}"
+      sleep 10
+      n=$(( n + 1 ))
+    else
+      # If we're here, we were successful
+      break
+    fi
+done
+
+CONSUL_TOKEN=$(vault kv get -field master_token kv/consul)
+
+#aws
+n=1
+while /bin/true; do
+    echo "Checking AWS TGW, loop ${n}"
+    aws_tgw=$(curl -s -H "X-Consul-Token: ${CONSUL_TOKEN}" "${CONSUL_HTTP_ADDR}/v1/health/service/aws-us-east-1-terminating-gateway?dc=aws-us-east-1&passing=true")
+    count=$(echo "${aws_tgw}" | jq '. | length')
+    if [ "${count}" != "1" ]; then
+      echo "AWS TGW is not healthy, got ${count}"
+      sleep 10
+      n=$(( n + 1 ))
+    else
+      # If we got here, we were successful
+      break
+    fi
+done
+
+#azure
+n=1
+while /bin/true; do
+    echo "Checking Azure TGW, loop ${n}"
+    azure_tgw=$(curl -s -H "X-Consul-Token: ${CONSUL_TOKEN}" "${CONSUL_HTTP_ADDR}/v1/health/service/azure-west-us-2-terminating-gateway?dc=azure-west-us-2&passing=true")
+    count=$(echo "${azure_tgw}" | jq '. | length')
+    if [ "${count}" != "1" ]; then
+      echo "Azure TGW is not healthy, got ${count}"
+      sleep 10
+      n=$(( n + 1 ))
+    else
+      # If we got here, we were successful
+      break
+    fi
+done
+
+#cts
+n=1
+while /bin/true; do
+    echo "cts sg check, loop ${n}"
+    cts_sg=$(aws ec2 describe-security-groups --filter Name="group-id",Values="$(terraform output -state /root/terraform/cache-services/terraform.tfstate elasticache_sg)" | jq '.SecurityGroups[0].IpPermissions[0].IpRanges | length')
+    if [ "${cts_sg}" != "2" ]; then
+      echo "CTS did not work. Expecting 2 SG rules, got ${cts_sg}."
+      sleep 10
+      n=$(( n + 1 ))
+    else
+      # If we got here, we were successful
+      break
+    fi
+done
+# IL-613
 
 exit 0

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/19-deploy-product-applications/check-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/19-deploy-product-applications/check-cloud-client
@@ -4,7 +4,7 @@ set -euvxo pipefail
 #creds
 vault login -method=userpass username=admin password=admin
 
-#aws
+#azure
 azure_products=$(curl -s -H "X-Consul-Token: $(vault kv get -field master_token kv/consul)" "${CONSUL_HTTP_ADDR}/v1/health/service/product-api?dc=azure-west-us-2&ns=product&passing=true")
 if [ "$(echo "${azure_products}" | jq '. | length')" != "1" ]; then
   fail-message "Azure product-api is not healthy"

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/19-deploy-product-applications/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/19-deploy-product-applications/solve-cloud-client
@@ -2,6 +2,25 @@
 set -euvxo pipefail
 
 terraform apply -auto-approve 2>&1 | tee terraform.out
-sleep 120
+
+# IL-613 wait until product API is happy
+echo "Checking product api"
+vault login -method=userpass username=admin password=admin
+consul_token=$(vault kv get -field master_token kv/consul)
+
+n=1
+while /bin/true; do
+    echo "Product api check ${n}"
+    azure_products=$(curl -s -H "X-Consul-Token: ${consul_token}" "${CONSUL_HTTP_ADDR}/v1/health/service/product-api?dc=azure-west-us-2&ns=product&passing=true")
+    if [ "$(echo "${azure_products}" | jq '. | length')" != "1" ]; then
+        echo "Not healthy yet"
+	n=$(( n + 1 ))
+        sleep 20
+    else
+        echo "Healthy"
+        break
+    fi
+done
+# IL-613
 
 exit 0

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/20-deploy-frontend-applications/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/20-deploy-frontend-applications/solve-cloud-client
@@ -9,6 +9,34 @@ helm install nginx-ingress -f /root/helm/nginx-ingress.yml ingress-nginx/ingress
 sleep 10
 kubectl apply -f k8s/web
 
-sleep 60
+# IL-613 wait until both applications are healthy
+#creds
+vault login -method=userpass username=admin password=admin
+consul_token=$(vault kv get -field master_token kv/consul)
+
+n=0
+while /bin/true; do
+    echo "Loop ${n}"
+    gcp_frontend=$(curl -s -H "X-Consul-Token: ${consul_token}" "${CONSUL_HTTP_ADDR}/v1/health/service/web?dc=gcp-us-central-1&ns=frontend&passing=true")
+    count=$(echo "${gcp_frontend}" | jq '. | length')
+    if [ "${count}" != "2" ]; then
+      echo "GKE web app is not healthy. Expecting 2 instances, got ${count}."
+      sleep 20
+      n=$(( n + 1 ))
+      continue
+    fi
+
+    gcp_public_api=$(curl -s -H "X-Consul-Token: ${consul_token}" "${CONSUL_HTTP_ADDR}/v1/health/service/public-api?dc=gcp-us-central-1&ns=frontend&passing=true")
+    count=$(echo "${gcp_public_api}" | jq '. | length')
+    if [ "${count}" != "2" ]; then
+      echo "GKE public-api app is not healthy. Expecting 2 instances, got ${count}."
+      sleep 20
+      n=$(( n + 1 ))
+    fi
+
+    # We got here, so both are healthy, break out of loop
+    break
+done
+# IL-613
 
 exit 0

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
@@ -36,7 +36,7 @@ resource "google_container_cluster" "shared" {
       recurrence = "FREQ=WEEKLY;WKST=SU;BYDAY=SA,SU"
     }
   }
-  # IL-495
+  # IL-613
 
   node_config {
     service_account = data.terraform_remote_state.iam.outputs.gcp_consul_service_account_email

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
@@ -20,9 +20,9 @@ resource "google_container_cluster" "shared" {
     }
   }
 
-  # IL-495
-  min_master_version = "1.21.14-gke.8500"
-  node_version       = "1.21.14-gke.8500"
+  # IL-613
+  min_master_version = "1.21.14-gke.18100"
+  node_version       = "1.21.14-gke.18100"
   # GKE mandates at least 48hr of maintenance window in a 32 day period.
   # We don't want upgrades during a lab, so we use the below values.
   # Choose two six-hour windows on Saturday and Sunday.

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
@@ -20,9 +20,9 @@ resource "google_container_cluster" "graphql" {
     }
   }
 
-  # IL-495
-  min_master_version = "1.21.14-gke.8500"
-  node_version       = "1.21.14-gke.8500"
+  # IL-613
+  min_master_version = "1.21.14-gke.18100"
+  node_version       = "1.21.14-gke.18100"
   # GKE mandates at least 48hr of maintenance window in a 32 day period.
   # We don't want upgrades during a lab, so we use the below values.
   # Choose two six-hour windows on Saturday and Sunday.
@@ -36,7 +36,7 @@ resource "google_container_cluster" "graphql" {
       recurrence = "FREQ=WEEKLY;WKST=SU;BYDAY=SA,SU"
     }
   }
-  # IL-495
+  # IL-613
 
   node_config {
     service_account = data.terraform_remote_state.iam.outputs.gcp_consul_service_account_email
@@ -79,9 +79,9 @@ resource "google_container_cluster" "react" {
     }
   }
 
-  # IL-495
-  min_master_version = "1.21.14-gke.8500"
-  node_version       = "1.21.14-gke.8500"
+  # IL-613
+  min_master_version = "1.21.14-gke.18100"
+  node_version       = "1.21.14-gke.18100"
   # GKE mandates at least 48hr of maintenance window in a 32 day period.
   # We don't want upgrades during a lab, so we use the below values.
   # Choose two six-hour windows on Saturday and Sunday.
@@ -95,7 +95,7 @@ resource "google_container_cluster" "react" {
       recurrence = "FREQ=WEEKLY;WKST=SU;BYDAY=SA,SU"
     }
   }
-  # IL-495
+  # IL-613
 
   node_config {
     service_account = data.terraform_remote_state.iam.outputs.gcp_consul_service_account_email

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euvxo pipefail
+set -euvo pipefail
 
 # Note: override these when testing from a different repo and/or branch
 #       The `-b` option to `git clone` is useful for pulling from the
@@ -55,7 +55,9 @@ apt-get --only-upgrade -y install google-cloud-sdk kubectl
 
 # Ensure we load /etc/profile.d/instruqt-env.sh
 echo "source /etc/profile.d/instruqt-env.sh" >> /root/.bashrc
+set +v
 source /root/.bashrc
+set -euvo pipefail
 
 # Azure account setup
 az account clear


### PR DESCRIPTION
* Bump GKE cluster version to meet minimum requirements
* Fix various spurious nightly/test track errors when resources created in the `solve-*` scripts aren't yet ready by the time the `check-*` scripts run. More to be done in other challenges, but these are the ones which came up while addressing the current issue. We do this by waiting until those resources are ready before exiting the `solve-*` scripts