### PR TITLE
IL-642 Use latest version of GKE clusters in 1.21.14 line

### DIFF
--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
@@ -1,8 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+data "google_container_engine_versions" "shared" {
+  project        = var.gcp_project_id
+  location       = "us-central1-a"
+  version_prefix = "1.21.14-gke."
+}
+
 resource "google_container_cluster" "shared" {
-  provider           = google-beta
   project            = var.gcp_project_id
   name               = "shared-${data.terraform_remote_state.infra.outputs.env}"
   location           = "us-central1-a"
@@ -20,9 +25,8 @@ resource "google_container_cluster" "shared" {
     }
   }
 
-  # IL-613
-  min_master_version = "1.21.14-gke.18100"
-  node_version       = "1.21.14-gke.18100"
+  min_master_version = data.google_container_engine_versions.shared.latest_master_version
+  node_version       = data.google_container_engine_versions.shared.latest_node_version
   # GKE mandates at least 48hr of maintenance window in a 32 day period.
   # We don't want upgrades during a lab, so we use the below values.
   # Choose two six-hour windows on Saturday and Sunday.
@@ -36,7 +40,6 @@ resource "google_container_cluster" "shared" {
       recurrence = "FREQ=WEEKLY;WKST=SU;BYDAY=SA,SU"
     }
   }
-  # IL-613
 
   node_config {
     service_account = data.terraform_remote_state.iam.outputs.gcp_consul_service_account_email

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
@@ -1,6 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+data "google_container_engine_versions" "k8s_schedulers" {
+  project        = var.gcp_project_id
+  location       = "us-central1-a"
+  version_prefix = "1.21.14-gke."
+}
+
 resource "google_container_cluster" "graphql" {
   provider           = google-beta
   project            = var.gcp_project_id
@@ -20,9 +26,8 @@ resource "google_container_cluster" "graphql" {
     }
   }
 
-  # IL-613
-  min_master_version = "1.21.14-gke.18100"
-  node_version       = "1.21.14-gke.18100"
+  min_master_version = data.google_container_engine_versions.k8s_schedulers.latest_master_version
+  node_version       = data.google_container_engine_versions.k8s_schedulers.latest_node_version
   # GKE mandates at least 48hr of maintenance window in a 32 day period.
   # We don't want upgrades during a lab, so we use the below values.
   # Choose two six-hour windows on Saturday and Sunday.
@@ -36,7 +41,6 @@ resource "google_container_cluster" "graphql" {
       recurrence = "FREQ=WEEKLY;WKST=SU;BYDAY=SA,SU"
     }
   }
-  # IL-613
 
   node_config {
     service_account = data.terraform_remote_state.iam.outputs.gcp_consul_service_account_email
@@ -79,9 +83,8 @@ resource "google_container_cluster" "react" {
     }
   }
 
-  # IL-613
-  min_master_version = "1.21.14-gke.18100"
-  node_version       = "1.21.14-gke.18100"
+  min_master_version = data.google_container_engine_versions.k8s_schedulers.latest_master_version
+  node_version       = data.google_container_engine_versions.k8s_schedulers.latest_node_version
   # GKE mandates at least 48hr of maintenance window in a 32 day period.
   # We don't want upgrades during a lab, so we use the below values.
   # Choose two six-hour windows on Saturday and Sunday.
@@ -95,7 +98,6 @@ resource "google_container_cluster" "react" {
       recurrence = "FREQ=WEEKLY;WKST=SU;BYDAY=SA,SU"
     }
   }
-  # IL-613
 
   node_config {
     service_account = data.terraform_remote_state.iam.outputs.gcp_consul_service_account_email

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
@@ -8,7 +8,6 @@ data "google_container_engine_versions" "k8s_schedulers" {
 }
 
 resource "google_container_cluster" "graphql" {
-  provider           = google-beta
   project            = var.gcp_project_id
   name               = "graphql-${data.terraform_remote_state.infra.outputs.env}"
   location           = "us-central1-a"
@@ -65,7 +64,6 @@ resource "google_container_cluster" "graphql" {
 }
 
 resource "google_container_cluster" "react" {
-  provider           = google-beta
   project            = var.gcp_project_id
   name               = "react-${data.terraform_remote_state.infra.outputs.env}"
   location           = "us-central1-a"


### PR DESCRIPTION
Let's ask what the latest version is with a data source and use it, so we stop breaking every time a new GKE release in the line comes out