### PR TITLE
IL-720 Quote here-doc delimiter in GitHub Actions

### DIFF
--- a/.github/workflows/instruqt-track-deploy.yml
+++ b/.github/workflows/instruqt-track-deploy.yml
@@ -54,10 +54,9 @@ jobs:
     - name: Get Jobs State
       id: get-jobs-state
       run: |-
-        cat<<EOF >> job-state.json
+        cat<<"EOF" >> job-state.json
         ${{ toJSON(github) }}
         EOF
-        cat job-state.json
     - name: Build Message
       id: build-message
       shell: python

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -131,10 +131,9 @@ jobs:
       - name: Get Jobs State
         id: get-jobs-state
         run: |-
-          cat<<EOF >> job-state.json
+          cat<<"EOF" >> job-state.json
           ${{ toJSON(needs) }}
           EOF
-          cat job-state.json
       - name: Build Message
         id: build-message
         shell: python


### PR DESCRIPTION
When we do things in GitHub Action Workflows to shove state into json files for parsing later on, e.g.:

 cat<<EOF > state.json
 ${{ toJSON(github) }}
 EOF

Bash will attempt to do any expansion of the resultant body as it is writing it to the file. We likely don't want expansion anyways, and in any case when expansion happens it may no longer be valid JSON and cause errors when trying to consume it later on.

If you however do:

  cat<<"EOF" > state.json
  [...]

by quoting any part of the here-doc delimiter, Bash won't do inline expansion.