### PR TITLE
IL-800 Adjust Azure VM read timeouts

### DIFF
--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/app/vmss_app.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/app/vmss_app.tf
@@ -62,6 +62,11 @@ resource "azurerm_virtual_machine_scale_set" "app_vmss" {
       primary   = true
     }
   }
+
+  timeouts {
+    read = "60m"
+  }
+
 }
 
 resource "azurerm_network_security_group" "app-sg" {

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/app/vmss_web.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/app/vmss_web.tf
@@ -62,6 +62,11 @@ resource "azurerm_virtual_machine_scale_set" "web_vmss" {
       primary   = true
     }
   }
+  
+  timeouts {
+    read = "60m"
+  }
+
 }
 
 resource "azurerm_network_security_group" "webserver-sg" {

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/consul-server/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/consul-server/main.tf
@@ -140,6 +140,10 @@ resource "azurerm_virtual_machine" "consul-server-vm" {
     }
 
   }
+  
+  timeouts {
+    read = "60m"
+  }
 
 }
 

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/consul-tf-sync/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/consul-tf-sync/main.tf
@@ -68,6 +68,10 @@ resource "azurerm_virtual_machine" "consul-terraform-sync" {
 
   }
 
+  timeouts {
+    read = "60m"
+  }
+
 }
 
 resource "azurerm_network_interface_security_group_association" "cts" {

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/panw-vm/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/panw-vm/main.tf
@@ -191,4 +191,9 @@ resource "azurerm_virtual_machine" "PAN_FW_FW" {
   os_profile_linux_config {
     disable_password_authentication = false
   }
+  
+  timeouts {
+    read = "60m"
+  }
+
 }

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/vault/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/vault/main.tf
@@ -117,6 +117,10 @@ resource "azurerm_virtual_machine" "vault" {
   tags = {
     environment = "staging"
   }
+
+  timeouts {
+    read = "60m"
+  }
 }
 
 resource "azurerm_network_security_group" "vault" {

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/vnet/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/vnet/main.tf
@@ -105,6 +105,11 @@ resource "azurerm_virtual_machine" "bastion" {
   tags = {
     environment = "staging"
   }
+  
+  timeouts {
+    read = "60m"
+  }
+
 }
 
 resource "azurerm_network_security_group" "bastion" {


### PR DESCRIPTION
Added the following blocks to all `azurerm_virtual_machine` and `azurerm_virtual_machine_scale_set`:

```
timeouts {
  read = "60m"
}
```

What’s happening, I believe, is that Azure takes forever to make VMs, and will lie about having created it, so the Azure provider makes the call to create a resource, then sits there polling for it. If it takes longer than five minutes (the default setting for the read timeout), then it gives up. When it gives up, the resource isn’t put in the Terraform state.

In this track we pre-provision a bunch of stuff during the track setup so that it’s ready for students as they go through the challenges. So we try to create a VM during track setup, it takes too long, Terraform gives up. Then we get to the challenge where we’d use that resource, and we run the Terraform command (like we tell students to do during that challenge) to create those resources. By that point the VM exists, but because it isn’t in the Terraform state TF tries to create it again, sees that it already exists, and tells you “This already exists, you need to import this resource into your Terraform state”, which is not only confusing for a student but also gums up our test suite. 