### PR TITLE
IL-798 Fix GKE issues

### DIFF
--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/09-provision-gcp-consul-secondary-datacenter/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/09-provision-gcp-consul-secondary-datacenter/solve-cloud-client
@@ -43,7 +43,7 @@ sleep 5
 
 #license & helm install
 kubectl create secret generic consul-ent-license --from-literal="key=$(cat /etc/consul.hclic)"
-helm install hashicorp hashicorp/consul -f /root/helm/gke-consul-values.yaml --debug --wait --version 0.33.0
+helm install hashicorp hashicorp/consul -f /root/helm/gke-consul-values.yaml --debug --wait --version 0.35.0
 sleep 60
 
 exit 0

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/16-provision-k8s-scheduler-services/solve-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/16-provision-k8s-scheduler-services/solve-cloud-client
@@ -19,7 +19,7 @@ kubectl config use-context react
 kubectl create secret generic hashicorp-consul-ca-cert --from-literal="tls.crt=$(vault read -field certificate pki/cert/ca)"
 kubectl create secret generic hashicorp-consul-gossip-key --from-literal="key=$(vault kv get -field=gossip_key kv/consul)"
 kubectl create secret generic bootstrap-token --from-literal="token=$(vault read -field token consul/creds/operator)"
-helm install consul hashicorp/consul --set externalServers.k8sAuthMethodHost="https://$(terraform output gcp_gke_cluster_react_endpoint)" -f /root/helm/react-consul-values.yaml --debug --wait --timeout 10m --version 0.33.0
+helm install consul hashicorp/consul --set externalServers.k8sAuthMethodHost="https://$(terraform output gcp_gke_cluster_react_endpoint)" -f /root/helm/react-consul-values.yaml --debug --wait --timeout 10m --version 0.35.0
 
 #graphql
 gcloud container clusters get-credentials $(terraform output -state /root/terraform/k8s-scheduler-services/terraform.tfstate gcp_gke_cluster_graphql_name) --region us-central1-a
@@ -28,6 +28,6 @@ kubectl config use-context graphql
 kubectl create secret generic hashicorp-consul-ca-cert --from-literal="tls.crt=$(vault read -field certificate pki/cert/ca)"
 kubectl create secret generic hashicorp-consul-gossip-key --from-literal="key=$(vault kv get -field=gossip_key kv/consul)"
 kubectl create secret generic bootstrap-token --from-literal="token=$(vault read -field token consul/creds/operator)"
-helm install consul hashicorp/consul --set externalServers.k8sAuthMethodHost="https://$(terraform output gcp_gke_cluster_graphql_endpoint)" -f /root/helm/graphql-consul-values.yaml --debug --wait --timeout 10m --version 0.33.0
+helm install consul hashicorp/consul --set externalServers.k8sAuthMethodHost="https://$(terraform output gcp_gke_cluster_graphql_endpoint)" -f /root/helm/graphql-consul-values.yaml --debug --wait --timeout 10m --version 0.35.0
 
 exit 0

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
@@ -25,8 +25,12 @@ resource "google_container_cluster" "shared" {
     }
   }
 
+  # IL-798 At creation the node_version must be set to the same as
+  # min_master_version, so use the same setting for both instead of
+  # `latest_node_version` from the data source
   min_master_version = data.google_container_engine_versions.shared.latest_master_version
-  node_version       = data.google_container_engine_versions.shared.latest_node_version
+  node_version       = data.google_container_engine_versions.shared.latest_master_version
+
   # GKE mandates at least 48hr of maintenance window in a 32 day period.
   # We don't want upgrades during a lab, so we use the below values.
   # Choose two six-hour windows on Saturday and Sunday.

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/gcp-consul-secondary/gke.tf
@@ -4,7 +4,7 @@
 data "google_container_engine_versions" "shared" {
   project        = var.gcp_project_id
   location       = "us-central1-a"
-  version_prefix = "1.21.14-gke."
+  version_prefix = "1.23.17-gke."
 }
 
 resource "google_container_cluster" "shared" {

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/assets/terraform/k8s-scheduler-services/gke.tf
@@ -4,7 +4,7 @@
 data "google_container_engine_versions" "k8s_schedulers" {
   project        = var.gcp_project_id
   location       = "us-central1-a"
-  version_prefix = "1.21.14-gke."
+  version_prefix = "1.23.17-gke."
 }
 
 resource "google_container_cluster" "graphql" {
@@ -25,8 +25,13 @@ resource "google_container_cluster" "graphql" {
     }
   }
 
+  # IL-798 At creation the node_version must be set to the same as
+  # min_master_version, so use the same setting for both instead of
+  # `latest_node_version` from the data source
+
   min_master_version = data.google_container_engine_versions.k8s_schedulers.latest_master_version
-  node_version       = data.google_container_engine_versions.k8s_schedulers.latest_node_version
+  node_version       = data.google_container_engine_versions.k8s_schedulers.latest_master_version
+
   # GKE mandates at least 48hr of maintenance window in a 32 day period.
   # We don't want upgrades during a lab, so we use the below values.
   # Choose two six-hour windows on Saturday and Sunday.
@@ -81,8 +86,13 @@ resource "google_container_cluster" "react" {
     }
   }
 
+  # IL-798 At creation the node_version must be set to the same as
+  # min_master_version, so use the same setting for both instead of
+  # `latest_node_version` from the data source
+
   min_master_version = data.google_container_engine_versions.k8s_schedulers.latest_master_version
-  node_version       = data.google_container_engine_versions.k8s_schedulers.latest_node_version
+  node_version       = data.google_container_engine_versions.k8s_schedulers.latest_master_version
+
   # GKE mandates at least 48hr of maintenance window in a 32 day period.
   # We don't want upgrades during a lab, so we use the below values.
   # Choose two six-hour windows on Saturday and Sunday.

--- a/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
+++ b/instruqt-tracks/multi-cloud-service-networking-with-consul/track_scripts/setup-cloud-client
@@ -355,7 +355,7 @@ fi
 n=0
 until [ $n -ge 5 ]; do
     vault_lb=$(terraform output -state /root/terraform/vault/terraform.tfstate aws_vault_ip)
-    echo "Vault Load balancer is: ${vault_lb}"
+    echo "AWS Vault Load balancer is: ${vault_lb}"
     if [ -z "${vault_lb}" ]; then
       fail-message "AWS Vault is not provisioned yet"
       n=$[$n+1]
@@ -363,6 +363,14 @@ until [ $n -ge 5 ]; do
       continue
     fi
     vault_api=$(curl -s -o /dev/null -w "%{http_code}" http://${vault_lb}:8200/v1/sys/health)
+    ec=$?
+    if [ $ec -ne 0 ]; then
+      fail-message "Checking AWS Vault LB failed with $ec"
+      n=$[$n+1]
+      sleep 60
+      continue
+    fi
+
     if [ "${vault_api}" != "501" ]; then
       fail-message "AWS Vault service did not return a 501. Please wait a few moments and try again."
       n=$[$n+1]
@@ -380,7 +388,7 @@ fi
 n=0
 until [ $n -ge 5 ]; do
     vault_lb=$(terraform output -state /root/terraform/vault/terraform.tfstate azure_vault_ip)
-    echo "Vault Load balancer is: ${vault_lb}"
+    echo "Azure Vault Load balancer is: ${vault_lb}"
     if [ -z "${vault_lb}" ]; then
       fail-message "Azure Vault is not provisioned yet"
       n=$[$n+1]
@@ -388,6 +396,14 @@ until [ $n -ge 5 ]; do
       continue
     fi
     vault_api=$(curl -s -o /dev/null -w "%{http_code}" http://${vault_lb}:8200/v1/sys/health)
+    ec=$?
+    if [ $ec -ne 0 ]; then
+      fail-message "Checking Azure Vault LB failed with $ec"
+      n=$[$n+1]
+      sleep 60
+      continue
+    fi
+
     if [ "${vault_api}" != "501" ]; then
       fail-message "Azure Vault service did not return a 501. Please wait a few moments and try again."
       n=$[$n+1]


### PR DESCRIPTION
Move GKE clusters to 1.23.17-gke line - 1.21.4 is no longer available, and I believe we were thus getting 1.27, which is way newer than what the Helm chart we use was tested on, and that caused failures. We can't bump the Helm chart too high, because then that bumps the Consul version we need to use too high to work with the clusters we have in VMs, and at this point we don't have the effort to re-build the entire track.