### PR TITLE
IL-843 Make NIA track deal with Azure better

### DIFF
--- a/instruqt-tracks/network-infrastructure-automation/3-provision-core-services/check-workstation
+++ b/instruqt-tracks/network-infrastructure-automation/3-provision-core-services/check-workstation
@@ -6,7 +6,7 @@ rg=$(terraform output -state /root/terraform/vnet/terraform.tfstate resource_gro
 
 #check vault
 echo "Checking Vault..."
-status=$(az vm show -g "${rg}" --name vault-vm | jq -r '.provisioningState')
+status=$(az vm show -g "${rg}" --name vault | jq -r '.provisioningState')
 if [ "${status}" != "Creating" ] && [ "${status}" != "Updating" ] && [ "${status}" != "Succeeded" ] ; then
   fail-message "Vault is not provisioning/provisioned. Wait a few moments and try again. Current state is: ${status}"
   exit 1

--- a/instruqt-tracks/network-infrastructure-automation/3-provision-core-services/solve-workstation
+++ b/instruqt-tracks/network-infrastructure-automation/3-provision-core-services/solve-workstation
@@ -54,7 +54,7 @@ done
 #check vault
 echo "Checking Vault..."
 while /bin/true; do
-    status=$(az vm show -g "${rg}" --name vault-vm | jq -r '.provisioningState')
+    status=$(az vm show -g "${rg}" --name vault | jq -r '.provisioningState')
     if [ "${status}" != "Creating" ] && [ "${status}" != "Updating" ] && [ "${status}" != "Succeeded" ] ; then
 	echo "Vault is not provisioning/provisioned, current state is: ${status}"
 	sleep 10

--- a/instruqt-tracks/network-infrastructure-automation/8-install-consul-terraform-sync/solve-workstation
+++ b/instruqt-tracks/network-infrastructure-automation/8-install-consul-terraform-sync/solve-workstation
@@ -10,7 +10,8 @@ terraform apply -auto-approve > /root/terraform/consul-tf-sync/terraform.out
 
 # Wait until things are actually set up
 n=0
-until [ $n -ge 20 ]; do
+while /bin/true; do
+    n=$((n+1))
     echo "Try ${n}"
     rg=$(terraform output -state /root/terraform/vnet/terraform.tfstate resource_group_name)
     echo "Checking consul-terraform-sync instance in resource group $rg:"
@@ -19,8 +20,7 @@ until [ $n -ge 20 ]; do
 
     if [ "${status}" != "Creating" ] && [ "${status}" != "Updating" ] && [ "${status}" != "Succeeded" ] ; then
       echo "consul-terraform-sync instance is not provisioned, current state is: ${status}. Sleeping and retrying."
-      sleep 60
-      n=$[$n+1]
+      sleep 20
       continue
     fi
 
@@ -28,8 +28,7 @@ until [ $n -ge 20 ]; do
     app=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080)
     if [ "${app}" != "200" ]; then
       echo "App did not return a 200, returned ${app}. Sleeping and retrying."
-      n=$[$n+1]
-      sleep 60
+      sleep 20
       continue
     fi
 

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/app/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/app/main.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 provider "azurerm" {
-  version = "=2.0.0"
+  version = "=3.72.0"
   features {}
 }
 

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/app/vmss_app.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/app/vmss_app.tf
@@ -2,57 +2,49 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-resource "azurerm_virtual_machine_scale_set" "app_vmss" {
+resource "azurerm_linux_virtual_machine_scale_set" "app_vmss" {
   name = "app-vmss"
 
   location            = data.terraform_remote_state.vnet.outputs.resource_group_location
   resource_group_name = data.terraform_remote_state.vnet.outputs.resource_group_name
 
-  upgrade_policy_mode = "Manual"
+  upgrade_mode        = "Manual"
 
-  sku {
-    name     = "Standard_DS1_v2"
-    tier     = "Standard"
-    capacity = var.app_count
-  }
+  sku                 = "Standard_DS1_v2"
+  instances           = var.app_count
 
-  storage_profile_image_reference {
+  source_image_reference {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-LTS-gen2"
     version   = "latest"
   }
 
-  storage_profile_os_disk {
-    name              = ""
-    caching           = "ReadWrite"
-    create_option     = "FromImage"
-    managed_disk_type = "Standard_LRS"
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
   }
 
-  storage_profile_data_disk {
-    lun           = 0
-    caching       = "ReadWrite"
-    create_option = "Empty"
-    disk_size_gb  = 10
+  data_disk {
+    lun                  = 0
+    caching              = "ReadWrite"
+    create_option        = "Empty"
+    disk_size_gb         = 10
+    storage_account_type = "Standard_LRS"
   }
 
-  os_profile {
-    computer_name_prefix = "app-vm-"
-    admin_username       = "azure-user"
-    custom_data          = base64encode(templatefile("./templates/app_server.sh", { consul_server_ip = var.consul_server_ip }))
-      }
+  computer_name_prefix = "app-vm-"
+  admin_username       = "azure-user"
+  custom_data          = base64encode(templatefile("./templates/app_server.sh", { consul_server_ip = var.consul_server_ip }))
 
-  os_profile_linux_config {
-    disable_password_authentication = true
-    ssh_keys {
-      path     = "/home/azure-user/.ssh/authorized_keys"
-      key_data = var.ssh_public_key
-    }
+  disable_password_authentication = true
 
+  admin_ssh_key {
+    username   = "azure-user"
+    public_key = var.ssh_public_key
   }
 
-  network_profile {
+  network_interface {
     name                      = "app-vms-netprofile"
     primary                   = true
     network_security_group_id = azurerm_network_security_group.webserver-sg.id
@@ -64,7 +56,10 @@ resource "azurerm_virtual_machine_scale_set" "app_vmss" {
   }
 
   timeouts {
-    read = "60m"
+    create = "60m"
+    read   = "60m"
+    update = "60m"
+    delete = "60m"
   }
 
 }

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/app/vmss_web.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/app/vmss_web.tf
@@ -2,57 +2,50 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-resource "azurerm_virtual_machine_scale_set" "web_vmss" {
+resource "azurerm_linux_virtual_machine_scale_set" "web_vmss" {
   name = "web-vmss"
 
   location            = data.terraform_remote_state.vnet.outputs.resource_group_location
   resource_group_name = data.terraform_remote_state.vnet.outputs.resource_group_name
 
 
-  upgrade_policy_mode = "Manual"
+  upgrade_mode = "Manual"
 
-  sku {
-    name     = "Standard_DS1_v2"
-    tier     = "Standard"
-    capacity = var.web_count
-  }
+  sku                 = "Standard_DS1_v2"
+  instances           = var.web_count
 
-  storage_profile_image_reference {
+  source_image_reference {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-LTS-gen2"
     version   = "latest"
   }
 
-  storage_profile_os_disk {
-    name              = ""
-    caching           = "ReadWrite"
-    create_option     = "FromImage"
-    managed_disk_type = "Standard_LRS"
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
   }
 
-  storage_profile_data_disk {
-    lun           = 0
-    caching       = "ReadWrite"
-    create_option = "Empty"
-    disk_size_gb  = 10
+  data_disk {
+    lun                  = 0
+    caching              = "ReadWrite"
+    create_option        = "Empty"
+    disk_size_gb         = 10
+    storage_account_type = "Standard_LRS"
   }
 
-  os_profile {
-    computer_name_prefix = "web-vm-"
-    admin_username       = "azure-user"
-    custom_data          = base64encode(templatefile("./templates/web_server.sh", { consul_server_ip = var.consul_server_ip, bigip_mgmt_addr = var.bigip_mgmt_addr, vip_internal_address = var.vip_internal_address }))
+  computer_name_prefix = "web-vm-"
+  admin_username       = "azure-user"
+  custom_data          = base64encode(templatefile("./templates/web_server.sh", { consul_server_ip = var.consul_server_ip, bigip_mgmt_addr = var.bigip_mgmt_addr, vip_internal_address = var.vip_internal_address }))
+
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username   = "azure-user"
+    public_key = var.ssh_public_key
   }
 
-  os_profile_linux_config {
-    disable_password_authentication = true
-    ssh_keys {
-      path     = "/home/azure-user/.ssh/authorized_keys"
-      key_data = var.ssh_public_key
-    }
-  }
-
-  network_profile {
+  network_interface {
     name                      = "web-vms-netprofile"
     primary                   = true
     network_security_group_id = azurerm_network_security_group.webserver-sg.id
@@ -64,9 +57,11 @@ resource "azurerm_virtual_machine_scale_set" "web_vmss" {
   }
   
   timeouts {
-    read = "60m"
+    create = "60m"
+    read   = "60m"
+    update = "60m"
+    delete = "60m"
   }
-
 }
 
 resource "azurerm_network_security_group" "webserver-sg" {

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/bigip/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/bigip/main.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 provider "azurerm" {
-  version = "=2.0.0"
+  version = "=3.72.0"
   features {}
 }
 

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/consul-tf-sync/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/consul-tf-sync/main.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 provider "azurerm" {
-  version = "=2.0.0"
+  version = "=3.72.0"
   features {}
 }
 
@@ -29,47 +29,52 @@ resource "azurerm_network_interface" "cts-nic" {
     tags = {
         environment = "Instruqt"
     }
+  
+  timeouts {
+    create = "60m"
+    read   = "60m"
+    update = "60m"
+    delete = "60m"
+  }
 }
 
-resource "azurerm_virtual_machine" "consul-terraform-sync" {
+resource "azurerm_linux_virtual_machine" "consul-terraform-sync" {
   name = "consul-terraform-sync"
 
   location            = data.terraform_remote_state.vnet.outputs.resource_group_location
   resource_group_name = data.terraform_remote_state.vnet.outputs.resource_group_name
   network_interface_ids = [azurerm_network_interface.cts-nic.id]
-  vm_size               = "Standard_DS1_v2"
+  size                  = "Standard_DS1_v2"
 
-  storage_image_reference {
+  source_image_reference {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-LTS-gen2"
     version   = "latest"
   }
 
-  storage_os_disk {
-    name              = "ctsDisk"
-    caching           = "ReadWrite"
-    create_option     = "FromImage"
-    managed_disk_type = "Standard_LRS"
+  os_disk {
+    name                 = "ctsDisk"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
   }
 
-  os_profile {
-    computer_name = "consul-terraform-sync"
-    admin_username       = "azure-user"
-    custom_data          = base64encode(templatefile("./scripts/consul-tf-sync.sh", { vault_token = var.vault_token, vault_addr = var.vault_addr, consul_server_ip = var.consul_server_ip, bigip_mgmt_addr = var.bigip_mgmt_addr, bigip_admin_user = var.bigip_admin_user, panos_mgmt_addr = var.panos_mgmt_addr, panos_username = var.panos_username }))
-  }
+  computer_name        = "consul-terraform-sync"
+  admin_username       = "azure-user"
+  custom_data          = base64encode(templatefile("./scripts/consul-tf-sync.sh", { vault_token = var.vault_token, vault_addr = var.vault_addr, consul_server_ip = var.consul_server_ip, bigip_mgmt_addr = var.bigip_mgmt_addr, bigip_admin_user = var.bigip_admin_user, panos_mgmt_addr = var.panos_mgmt_addr, panos_username = var.panos_username }))
 
-  os_profile_linux_config {
-    disable_password_authentication = true
-    ssh_keys {
-      path     = "/home/azure-user/.ssh/authorized_keys"
-      key_data = var.ssh_public_key
-    }
+  disable_password_authentication = true
 
+  admin_ssh_key {
+    username   = "azure-user"
+    public_key = var.ssh_public_key
   }
 
   timeouts {
-    read = "60m"
+    create = "60m"
+    read   = "60m"
+    update = "60m"
+    delete = "60m"
   }
 
 }

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/panw-vm/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/panw-vm/main.tf
@@ -10,7 +10,7 @@ az vm image terms accept --urn paloaltonetworks:vmseries1:bundle1:latest
 */
 
 provider "azurerm" {
-  version = "=2.13.0"
+  version = "=3.72.0"
   features {}
 }
 
@@ -74,7 +74,7 @@ resource "azurerm_network_interface" "VNIC0" {
   ip_configuration {
     name                          = join("", list("ipconfig", "0"))
     subnet_id                     = data.terraform_remote_state.vnet.outputs.mgmt_subnet
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.IPAddressMgmtNetwork
     public_ip_address_id          = azurerm_public_ip.PublicIP_0.id
   }
@@ -94,7 +94,7 @@ resource "azurerm_network_interface" "VNIC1" {
   ip_configuration {
     name                          = join("", list("ipconfig", "1"))
     subnet_id                     = data.terraform_remote_state.vnet.outputs.internet_subnet
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.IPAddressInternetNetwork
     public_ip_address_id          = azurerm_public_ip.PublicIP_1.id
   }
@@ -114,7 +114,7 @@ resource "azurerm_network_interface" "VNIC2" {
   ip_configuration {
     name                          = join("", list("ipconfig", "2"))
     subnet_id                     = data.terraform_remote_state.vnet.outputs.dmz_subnet
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.IPAddressDmzNetwork
   }
 
@@ -133,7 +133,7 @@ resource "azurerm_network_interface" "VNIC3" {
   ip_configuration {
     name                          = join("", list("ipconfig", "3"))
     subnet_id                     = data.terraform_remote_state.vnet.outputs.app_subnet
-    private_ip_address_allocation = "static"
+    private_ip_address_allocation = "Static"
     private_ip_address            = var.IPAddressAppNetwork
   }
 
@@ -143,7 +143,10 @@ resource "azurerm_network_interface" "VNIC3" {
 }
 
 resource "azurerm_virtual_machine" "PAN_FW_FW" {
-  name                = "vmPANW-${random_id.suffix.dec}"
+  # IMPORTANT: IL-843 the Terraform resource name and the Azure
+  # VM name must match for our track setup script to clean up
+  # when Azure fails to make a VM
+  name                = "PAN_FW_FW"
   location            = data.terraform_remote_state.vnet.outputs.resource_group_location
   resource_group_name = data.terraform_remote_state.vnet.outputs.resource_group_name
   vm_size             = "Standard_D3_v2"
@@ -169,7 +172,10 @@ resource "azurerm_virtual_machine" "PAN_FW_FW" {
   }
 
   storage_os_disk {
-    name          = join("", list("vmPANW-${random_id.suffix.dec}", "-osDisk"))
+    # IMPORTANT: IL-843 the os disk name must be
+    # "<tf resource name>-disk" for our Azure cleanup script to
+    # work
+    name          = "PAN_FW_FW-disk"
     vhd_uri       = "${azurerm_storage_account.PAN_FW_STG_AC.primary_blob_endpoint}vhds/vmPANW-${random_id.suffix.dec}-${var.fwOffer}-${var.fwSku}.vhd"
     caching       = "ReadWrite"
     create_option = "FromImage"
@@ -193,7 +199,9 @@ resource "azurerm_virtual_machine" "PAN_FW_FW" {
   }
   
   timeouts {
-    read = "60m"
+    create = "60m"
+    read   = "60m"
+    update = "60m"
+    delete = "60m"
   }
-
 }

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/vault/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/vault/main.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 provider "azurerm" {
-  version = "=2.0.0"
+  version = "=3.72.0"
   features {}
 }
 
@@ -48,7 +48,6 @@ resource "azurerm_lb" "vault" {
 }
 
 resource "azurerm_lb_backend_address_pool" "vault" {
-  resource_group_name = data.terraform_remote_state.vnet.outputs.resource_group_name
   loadbalancer_id     = azurerm_lb.vault.id
   name                = "BackEndAddressPool"
 }
@@ -60,14 +59,12 @@ resource "azurerm_network_interface_backend_address_pool_association" "vault" {
 }
 
 resource "azurerm_lb_probe" "vault" {
-  resource_group_name = data.terraform_remote_state.vnet.outputs.resource_group_name
   loadbalancer_id     = azurerm_lb.vault.id
   name                = "vault-http"
   port                = 8200
 }
 
 resource "azurerm_lb_rule" "vault" {
-  resource_group_name            = data.terraform_remote_state.vnet.outputs.resource_group_name
   loadbalancer_id                = azurerm_lb.vault.id
   name                           = "vault"
   protocol                       = "Tcp"
@@ -75,43 +72,44 @@ resource "azurerm_lb_rule" "vault" {
   backend_port                   = 8200
   frontend_ip_configuration_name = "configuration"
   probe_id                       = azurerm_lb_probe.vault.id
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.vault.id
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.vault.id]
 }
 
-resource "azurerm_virtual_machine" "vault" {
-  name                  = "vault-vm"
+resource "azurerm_linux_virtual_machine" "vault" {
+  # IMPORTANT: IL-843 the Terraform resource name and the Azure
+  # VM name must match for our track setup script to clean up
+  # when Azure fails to make a VM
+  name                  = "vault"
   location              = data.terraform_remote_state.vnet.outputs.resource_group_location
   resource_group_name   = data.terraform_remote_state.vnet.outputs.resource_group_name
   network_interface_ids = [azurerm_network_interface.vault.id]
-  vm_size               = "Standard_DS1_v2"
+  size                  = "Standard_DS1_v2"
 
-  delete_os_disk_on_termination    = true
-  delete_data_disks_on_termination = true
-
-  storage_image_reference {
+  source_image_reference {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-LTS-gen2"
     version   = "latest"
   }
-  storage_os_disk {
-    name              = "vault-disk"
-    caching           = "ReadWrite"
-    create_option     = "FromImage"
-    managed_disk_type = "Standard_LRS"
-  }
-  os_profile {
-    computer_name  = "vault"
-    admin_username = "azure-user"
-    custom_data    = file("${path.module}/scripts/vault.sh")
+  
+  os_disk {
+    # IMPORTANT: IL-843 the os disk name must be
+    # "<tf resource name>-disk" for our Azure cleanup script to
+    # work
+    name                 = "vault-disk"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
   }
 
-  os_profile_linux_config {
-    disable_password_authentication = true
-    ssh_keys {
-      path     = "/home/azure-user/.ssh/authorized_keys"
-      key_data = var.ssh_public_key
-    }
+  computer_name  = "vault"
+  admin_username = "azure-user"
+  custom_data    = base64encode(file("${path.module}/scripts/vault.sh"))
+
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username   = "azure-user"
+    public_key = var.ssh_public_key
   }
 
   tags = {
@@ -119,7 +117,10 @@ resource "azurerm_virtual_machine" "vault" {
   }
 
   timeouts {
-    read = "60m"
+    create = "60m"
+    read   = "60m"
+    update = "60m"
+    delete = "60m"
   }
 }
 

--- a/instruqt-tracks/network-infrastructure-automation/assets/terraform/vnet/main.tf
+++ b/instruqt-tracks/network-infrastructure-automation/assets/terraform/vnet/main.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 provider "azurerm" {
-  version = "=2.13.0"
+  version = "=3.72.0"
   features {}
 }
 
@@ -67,39 +67,34 @@ resource "azurerm_network_interface" "bastion" {
   }
 }
 
-resource "azurerm_virtual_machine" "bastion" {
+resource "azurerm_linux_virtual_machine" "bastion" {
   name                  = "bastion-vm"
   location              = azurerm_resource_group.instruqt.location
   resource_group_name   = azurerm_resource_group.instruqt.name
   network_interface_ids = [azurerm_network_interface.bastion.id]
-  vm_size               = "Standard_DS1_v2"
+  size                  = "Standard_DS1_v2"
 
-  delete_os_disk_on_termination    = true
-  delete_data_disks_on_termination = true
-
-  storage_image_reference {
+  source_image_reference {
     publisher = "Canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-LTS-gen2"
     version   = "latest"
   }
-  storage_os_disk {
-    name              = "bastion-disk"
-    caching           = "ReadWrite"
-    create_option     = "FromImage"
-    managed_disk_type = "Standard_LRS"
-  }
-  os_profile {
-    computer_name  = "bastion"
-    admin_username = "azure-user"
+
+  os_disk {
+    name                 = "bastion-disk"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
   }
 
-  os_profile_linux_config {
-    disable_password_authentication = true
-    ssh_keys {
-      path     = "/home/azure-user/.ssh/authorized_keys"
-      key_data = var.ssh_public_key
-    }
+  computer_name  = "bastion"
+  admin_username = "azure-user"
+  
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username   = "azure-user"
+    public_key = var.ssh_public_key
   }
 
   tags = {
@@ -107,7 +102,10 @@ resource "azurerm_virtual_machine" "bastion" {
   }
   
   timeouts {
-    read = "60m"
+    create = "60m"
+    read   = "60m"
+    update = "60m"
+    delete = "60m"
   }
 
 }

--- a/instruqt-tracks/network-infrastructure-automation/track_scripts/setup-workstation
+++ b/instruqt-tracks/network-infrastructure-automation/track_scripts/setup-workstation
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euvxo pipefail
+
 # Note: override these when testing from a different repo and/or branch
 #       The `-b` option to `git clone` is useful for pulling from the
 #       non-default branch
@@ -41,7 +43,7 @@ until [ $n -ge 5 ]; do
   az login \
   --username "${INSTRUQT_AZURE_SUBSCRIPTION_CONSUL_USERNAME}" \
   --password "${INSTRUQT_AZURE_SUBSCRIPTION_CONSUL_PASSWORD}" && break
-  n=$[$n+1]
+    n=$((n+1))
   sleep 60
 done
 if [ $n -ge 5 ]; then
@@ -51,7 +53,11 @@ fi
 #get assets
 echo "cloning assets..."
 echo "git clone ${ASSET_REPO_FETCH_OPTIONS} ${ASSET_REPO}"
-git clone ${ASSET_REPO_FETCH_OPTIONS} ${ASSET_REPO}
+if [ -n "${ASSET_REPO_FETCH_OPTIONS}" ]; then
+    git clone ${ASSET_REPO_FETCH_OPTIONS} ${ASSET_REPO}
+else
+    git clone ${ASSET_REPO}
+fi
 cp -r field-workshops-consul/instruqt-tracks/network-infrastructure-automation/assets/terraform /root/terraform
 rm -rf field-workshops-consul
 
@@ -60,7 +66,7 @@ cat << EOF > ~/.ssh/config
 Host *
     StrictHostKeyChecking no
 EOF
-eval $(ssh-agent)
+eval "$(ssh-agent)"
 ssh-add ~/.ssh/id_rsa
 
 #seeing if this fixes the internittent 'subscription not recognized error'
@@ -70,10 +76,12 @@ az account set --subscription "${INSTRUQT_AZURE_SUBSCRIPTION_CONSUL_SUBSCRIPTION
 az provider register --namespace 'Microsoft.Solutions' --subscription "${INSTRUQT_AZURE_SUBSCRIPTION_CONSUL_SUBSCRIPTION_ID}"
 az vm image terms accept --urn paloaltonetworks:vmseries1:bundle1:latest
 
+
 #optimistic provisioning
 echo "starting optimistic provisioning..."
 
 #vnets
+echo "vnets"
 cd /root/terraform/vnet
 /usr/bin/terraform init
 cat << EOF > /root/terraform/vnet/terraform.tfvars
@@ -81,39 +89,192 @@ ssh_public_key = "$(cat ~/.ssh/id_rsa.pub)"
 EOF
 terraform apply -auto-approve 2>&1 | tee terraform.out
 
+# Please see IL-843 for more details; in short
+#
+# 1. In this script, we pre-provision resources to the actual challenges
+#    can go quickly
+# 2. Azure sometimes fails to create a VM, and leaves in Azure a half-created
+#    VM which isn't actually up, but for which Azure believes is sorta there.
+#    When this happens via TF, TF sees it take longer than ~10m to create a
+#    resource, and TF gives up. Terraform *does not* put any information about
+#    the VM in the state, because as far as TF knows, the thing doesn't yet
+#    exist. But Azure has it half-created
+# 3. In the challenge, when the student tries to run `terraform play` or
+#    `terraform apply`, they get told they need to create the VM, because
+#    as far as TF knows it doesn't exist. *However*, when TF tries to create
+#    it, it runs into the half-created VM state in Azure, and Azure goes
+#    "That already exists, you can't create it again.
+#
+# So we have to check for that. The fix is, in a loop:
+#
+# 1. `terraform apply -auto-approve`
+# 2. When done, `terraform state list` and see if the VM is there. If it
+#    is, exit, life is good
+# 3. If not, `az vm delete -g <resource group> -n <vm name>`
+# 4. And also `az disk delete -g <resource group> -n <disk name>`
+# 5. But a azurerm_virtual_machine in TF includes things like a managed
+#    disk, a NIC, etc, but those are separate entities in Azure. So if
+#    you tried to create the VM again, it would complain that the disk
+#    or NIC or whatever still exists. So we would `terraform destroy`
+#    here, *but* Azure won't let you delete a NIC which has been attached
+#    to a VM for less than 3 minutes, so sleep 181 seconds
+# 6. `terraform destroy -auto-approve`
+# 7. Goto step 1
+#
+# :sigh:
+#
+
+# helper function
+provision_resource() {
+    RESOURCE_NAME=$1
+    shift
+    RESOURCE_ADDR=$1
+    shift
+    RG=$(terraform output -state=/root/terraform/vnet/terraform.tfstate resource_group_name)
+
+    if [ -z "${RESOURCE_NAME}" ] || [ -z "${RESOURCE_ADDR}" ]; then
+	echo "ERROR call as provision_resource <RESOURCE_NAME> <RESOURCE_ADDR>"
+	exit 1
+    fi
+
+    TRY=1
+    while /bin/true; do
+	echo "Provisioning ${RESOURCE_ADDR} in $(pwd), try ${TRY}"
+	# Provision in a loop until the VM is created, Because Azure(TM)
+
+	# Provision
+	nohup terraform apply -auto-approve 2>&1 | tee nohup.out
+
+	# Does VM exist?
+	terraform state list "${RESOURCE_ADDR}"
+	ec=$?
+	if [ $ec -ne 0 ]; then
+	    echo "${RESOURCE_ADDR} doesn't exist after Terraform is finished"
+	    # Delete the half-created VM
+	    az vm delete -g "${RG}" -n "${RESOURCE_NAME}" --yes
+	    az disk delete -g "${RG}" -n "${RESOURCE_NAME}-disk" --yes
+	    sleep 185	# THIS VALUE IS IMPORTANT, see IL-843 before you change it
+	    terraform destroy -auto-approve
+	    TRY=$((TRY+1))
+	    # we've already waited 185 seconds at least, so no need to sleep
+	else
+	    echo "${RESOURCE_ADDR} provisioned"
+	    touch .provisioned
+	    break
+	fi
+    done
+    echo "Successfully created ${RESOURCE_ADDR} in $(pwd) on try ${TRY}"
+}
+
+
 #consul
-cd /root/terraform/consul-server
-terraform init
-cat << EOF > /root/terraform/consul-server/terraform.tfvars
+provision_consul() {
+    # We set +e here because commands may fail and we
+    # want to clean up
+    set +e
+
+    # Get resource group in case we need it later on
+    cd /root/terraform/vnet
+    RG=$(terraform output resource_group_name)
+
+    cd /root/terraform/consul-server
+    terraform init
+    cat << EOF > /root/terraform/consul-server/terraform.tfvars
 ssh_public_key = "$(cat ~/.ssh/id_rsa.pub)"
 EOF
-nohup terraform apply -auto-approve 2>&1 | tee nohup.out &
+    RESOURCE_NAME="consul-server-vm"
+    RESOURCE_ADDR="azurerm_linux_virtual_machine.${RESOURCE_NAME}"
+    provision_resource "${RESOURCE_NAME}" "${RESOURCE_ADDR}"
+}
 
 #vault
-cd /root/terraform/vault
-terraform init
-cat << EOF > /root/terraform/vault/terraform.tfvars
+provision_vault() {
+    # We set +e here because commands may fail and we
+    # want to clean up
+    set +e
+
+    cd /root/terraform/vault
+    terraform init
+    cat << EOF > /root/terraform/vault/terraform.tfvars
 ssh_public_key = "$(cat ~/.ssh/id_rsa.pub)"
 EOF
-nohup terraform apply -auto-approve 2>&1 | tee nohup.out &
+    RESOURCE_NAME="vault"
+    RESOURCE_ADDR="azurerm_linux_virtual_machine.${RESOURCE_NAME}"
+    provision_resource "${RESOURCE_NAME}" "${RESOURCE_ADDR}"
+}
 
 #f5
-cd /root/terraform/bigip
-terraform init
-terraform import azurerm_marketplace_agreement.f5 "/subscriptions/${INSTRUQT_AZURE_SUBSCRIPTION_CONSUL_SUBSCRIPTION_ID}/providers/Microsoft.MarketplaceOrdering/agreements/f5-networks/offers/f5-big-ip-good/plans/f5-bigip-virtual-edition-25m-good-hourly"
-nohup terraform apply -auto-approve 2>&1 | tee nohup.out &
+provision_f5() {
+    # We set +e here because commands may fail and we
+    # want to clean up
+    set +e
+
+    cd /root/terraform/bigip
+    terraform init
+    terraform import azurerm_marketplace_agreement.f5 "/subscriptions/${INSTRUQT_AZURE_SUBSCRIPTION_CONSUL_SUBSCRIPTION_ID}/providers/Microsoft.MarketplaceOrdering/agreements/f5-networks/offers/f5-big-ip-good/plans/f5-bigip-virtual-edition-25m-good-hourly"
+
+    RESOURCE_NAME="f5bigip"
+    RESOURCE_ADDR="azurerm_linux_virtual_machine.${RESOURCE_NAME}"
+    provision_resource "${RESOURCE_NAME}" "${RESOURCE_ADDR}"
+}
 
 #panw
-cd /root/terraform/panw-vm
-terraform init
-nohup terraform apply -auto-approve 2>&1 | tee nohup.out &
+provision_panw(){
+    # We set +e here because commands may fail and we
+    # want to clean up
+    set +e
 
-#wait for f5 & panw
-echo "Waiting for network devices..."
-sleep 600
+    cd /root/terraform/panw-vm
+    terraform init
+    RESOURCE_NAME="PAN_FW_FW"
+    RESOURCE_ADDR="azurerm_virtual_machine.${RESOURCE_NAME}"
+    provision_resource "${RESOURCE_NAME}" "${RESOURCE_ADDR}"
+}
+
+provision_consul &
+provision_vault &
+provision_f5 &
+provision_panw &
+
+# Wait for all resources to be provisioned
+while /bin/true; do
+    echo "Checking on provisioning"
+    SUCCESS=0
+    if [ -f /root/terraform/consul-server/.provisioned ]; then
+	echo "Consul done"
+	SUCCESS=$((SUCCESS+1))
+    fi
+
+    if [ -f /root/terraform/vault/.provisioned ]; then
+	echo "Vault done"
+	SUCCESS=$((SUCCESS+1))
+    fi
+
+    if [ -f /root/terraform/bigip/.provisioned ]; then
+	echo "BigIP done"
+	SUCCESS=$((SUCCESS+1))
+    fi
+
+    if [ -f /root/terraform/panw-vm/.provisioned ]; then
+	echo "Panw-VM done"
+	SUCCESS=$((SUCCESS+1))
+    fi
+
+    if [ "$SUCCESS" == "4" ]; then
+	echo "All done"
+	break
+    else
+	echo "Not all resources complete, sleeping and re-checking"
+	sleep 30
+    fi
+done
 
 #check devices
 echo "Running pre-flight checks..."
+
+# We're going to run checks that will fail past here, so turn
+# off -e
+set +e
 
 #f5
 echo "Checking PANW FW"
@@ -123,10 +284,11 @@ until [ $n -ge 10 ]; do
   firewall_ip=$(terraform output -state /root/terraform/panw-vm/terraform.tfstate FirewallIP)
   pa_username=$(terraform output -state /root/terraform/panw-vm/terraform.tfstate pa_username)
   pa_password=$(terraform output -state /root/terraform/panw-vm/terraform.tfstate pa_password)
-  if [ "$(curl -sk -o /dev/null  -u ${pa_username}:${pa_password} -w ''%{http_code}'' https://${firewall_ip}/restapi/v9.1/Device/VirtualSystems)" = "200" ]; then
+  http_code=$(curl -sk -o /dev/null  -u "${pa_username}:${pa_password}" -w "%{http_code}" https://"${firewall_ip}/restapi/v9.1/Device/VirtualSystems")
+  if [ "${http_code}" = "200" ]; then
       break
   fi
-  n=$[$n+1]
+  n=$((n+1))
   sleep 60
 done
 if [ $n -ge 10 ]; then
@@ -146,16 +308,12 @@ until [ $n -ge 5 ]; do
   if [ "${f5_status}" = "200" ]; then
     break
   fi
-  n=$[$n+1]
+  n=$((n+1))
   sleep 60
 done
 if [ $n -ge 5 ]; then
   fail-message "Could not check BIG-IP."
   exit 1
 fi
-
-#wait for network device boot up
-echo "Network Devices up! Waiting for init processes..."
-sleep 300
 
 exit 0


### PR DESCRIPTION
* Move the `azurerm` provider from 2.0.0 to 3.78.0
* Handle VM creation failures through a variety of techniques ** Most VMs are moved from `azurerm_virtual_machine` to
   `azurerm_linux_virtual_machine` (the current recommendation).
   Note that the PANW VM is not, because I couldn't quite figure
   out how to duplicate its configuration with the new resource
* Set resource timeouts on everything applicable here ** Note that, even with that, Azure itself will sometimes give up
   creating a VM after 10 minutes. When that happens, it returns
   a failure, so Terraform thinks the resource wasn't made and
   no information about it is put into the state file. But on
   the Azure side there's a "container" for that resource, so
   you could, for example, go into the Azure WebUI and see the
   VM, with a note that it failed to provision, but can't really
   fix it. Then, later on when we have the student do a Terraform
   apply because the resource isn't in the state file Terraform
   will try to create it and then report an error when Azure says
   that resource already exists.
* The fix is to, during the track setup script, ensure that the
   resource exists in the state file, and if it doesn't, run the
   Azure command to delete the VM as well as its OS disk, do a
   `terraform destroy`, and try again. Eventually it will succeed.