### PR TITLE
IL-884 Remove leading digits from challenge slugs

### DIFF
--- a/instruqt-tracks/consul-basics/01-meet-consul/assignment.md
+++ b/instruqt-tracks/consul-basics/01-meet-consul/assignment.md
@@ -1,5 +1,5 @@
 ---
-slug: 01-meet-consul
+slug: meet-consul
 type: challenge
 title: Get to Know Consul
 teaser: My First Consul cluster

--- a/instruqt-tracks/consul-basics/02-consul-cli/assignment.md
+++ b/instruqt-tracks/consul-basics/02-consul-cli/assignment.md
@@ -1,5 +1,5 @@
 ---
-slug: 02-consul-cli
+slug: consul-cli
 type: challenge
 title: Consul CLI
 teaser: Take the Consul CLI for a spin

--- a/instruqt-tracks/consul-basics/03-consul-api/assignment.md
+++ b/instruqt-tracks/consul-basics/03-consul-api/assignment.md
@@ -1,5 +1,5 @@
 ---
-slug: 03-consul-api
+slug: consul-api
 type: challenge
 title: Consul API
 teaser: Use the Consul API

--- a/instruqt-tracks/consul-basics/04-consul-agents/assignment.md
+++ b/instruqt-tracks/consul-basics/04-consul-agents/assignment.md
@@ -1,5 +1,5 @@
 ---
-slug: 04-consul-agents
+slug: consul-agents
 type: challenge
 title: Add an Agent
 teaser: Add a Consul client agent to your Consul cluster.

--- a/instruqt-tracks/consul-basics/05-consul-ha/assignment.md
+++ b/instruqt-tracks/consul-basics/05-consul-ha/assignment.md
@@ -1,5 +1,5 @@
 ---
-slug: 05-consul-ha
+slug: consul-ha
 type: challenge
 title: Consul High Availability
 teaser: Test Consul's High Availability Capabilities

--- a/instruqt-tracks/consul-basics/06-consul-acls/assignment.md
+++ b/instruqt-tracks/consul-basics/06-consul-acls/assignment.md
@@ -1,5 +1,5 @@
 ---
-slug: 06-consul-acls
+slug: consul-acls
 type: challenge
 title: Consul ACLs
 teaser: Set up basic Consul ACLs


### PR DESCRIPTION
Leftover from legacy configuration, having a slug `01-a-thing` causes Instruqt to assume the challenge directory is named `01-01-a-thing`, which is goofy and unnecessary.